### PR TITLE
Add email mapper, tests

### DIFF
--- a/oozie-to-airflow/README.md
+++ b/oozie-to-airflow/README.md
@@ -268,6 +268,27 @@ to the SSH node requires editing of an Airflow Connection to specify the
 spark cluster is running. This can be found under **Admin >> Connections**
 or created from the command line (see above).
 
+### Email Example
+
+The email example requires the configuration of a SMTP server in the `airflow.cfg` file. [An example SMTP config](https://github.com/apache/airflow/blob/master/airflow/config_templates/default_airflow.cfg#L330-L341)
+is shown below. Apache Oozie [only allows sending files from an HDFS cluster](https://oozie.apache.org/docs/4.3.1/DG_EmailActionExtension.html),
+and that is mimicked in the conversion.
+
+```
+[smtp]
+smtp_host = smtp.gmail.com
+smtp_starttls = True
+smtp_ssl = False
+smtp_user = <EMAIL_ADDR>
+smtp_password = <PASSWORD>
+smtp_port = 587
+smtp_mail_from = <EMAIL_ADDR>
+```
+
+After configuration, the examples can be ran as:
+
+`python oozie_converter.py -i examples/email/workflow.xml -p examples/email/job.properties -o output.py`
+
 ### EL Example
 
 The Oozie Expression Language (EL) example can be run as:

--- a/oozie-to-airflow/converter/oozie_parser.py
+++ b/oozie-to-airflow/converter/oozie_parser.py
@@ -25,6 +25,7 @@ import mappers.kill_mapper
 import mappers.null_mapper
 import mappers.spark_mapper
 import mappers.ssh_mapper
+import mappers.email_mapper
 import utils.xml_utils
 from converter.parsed_node import ParsedNode
 
@@ -41,6 +42,7 @@ ACTION_MAP = {
     'unknown': mappers.dummy_mapper.DummyMapper,
     'ssh': mappers.ssh_mapper.SSHMapper,
     'spark': mappers.spark_mapper.SparkMapper,
+    'email': mappers.email_mapper.EmailMapper,
 }
 
 

--- a/oozie-to-airflow/examples/email/job.properties
+++ b/oozie-to-airflow/examples/email/job.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+nameNode=hdfs://localhost:8020
+resourceManager=localhost:8032
+queueName=default
+examplesRoot=examples
+
+oozie.wf.application.path=${nameNode}/user/${user.name}/${examplesRoot}/apps/ssh

--- a/oozie-to-airflow/examples/email/workflow.xml
+++ b/oozie-to-airflow/examples/email/workflow.xml
@@ -1,0 +1,37 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<workflow-app xmlns="uri:oozie:workflow:1.0" name="ssh-wf">
+    <start to="an-email"/>
+
+    <action name="an-email">
+        <email xmlns="uri:oozie:email-action:0.1">
+            <to>bob@initech.com,the.other.bob@initech.com</to>
+            <cc>will@initech.com</cc>
+            <subject>Email notifications for ${wf:id()}</subject>
+            <body>The wf ${wf:id()} successfully completed.</body>
+        </email>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+
+    <kill name="fail">
+        <message>SSH action failed, error message[${wf:errorMessage(wf:lastErrorNode())}]</message>
+    </kill>
+
+    <end name="end"/>
+</workflow-app>

--- a/oozie-to-airflow/mappers/email_mapper.py
+++ b/oozie-to-airflow/mappers/email_mapper.py
@@ -1,0 +1,143 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import jinja2
+import logging
+
+from airflow.operators import email_operator
+from airflow.utils.trigger_rule import TriggerRule
+
+from definitions import ROOT_DIR
+from mappers.action_mapper import ActionMapper
+from o2a_libs import hdfs_helper_functions
+from utils import el_utils
+from utils import xml_utils
+
+# Required nodes are determined by the Oozie XML Schema
+REQ_NODES = ['to', 'subject', 'body']
+
+TO_TAG = 'to'
+SUBJECT_TAG = 'subject'
+BODY_TAG = 'body'
+CC_TAG = 'cc'
+BCC_TAG = 'bcc'
+CONTENT_TAG = 'content_type'
+ATTACH_TAG = 'attachment'
+
+MIXED = 'mixed'
+
+
+class EmailMapper(ActionMapper):
+    """
+    Converts an email oozie node to Airflow operator.
+
+    In order to use this, the user must specify an Airflow connection to use, and
+    provide the password there.
+
+    An action node looks like this, but we get passed the <email> node.
+
+    <action name="[NODE-NAME]">
+        <email xmlns="uri:oozie:email-action:0.2">
+            <to>[COMMA-SEPARATED-TO-ADDRESSES]</to>
+            <cc>[COMMA-SEPARATED-CC-ADDRESSES]</cc> <!-- cc is optional -->
+            <bcc>[COMMA-SEPARATED-BCC-ADDRESSES]</bcc> <!-- bcc is optional -->
+            <subject>[SUBJECT]</subject>
+            <body>[BODY]</body>
+            <content_type>[CONTENT-TYPE]</content_type> <!-- content_type is optional -->
+            <attachment>[COMMA-SEPARATED-HDFS-FILE-PATHS]</attachment> <!-- attachment is optional -->
+        </email>
+        <ok to="[NODE-NAME]"/>
+        <error to="[NODE-NAME]"/>
+    </action>
+    """
+
+    def __init__(self, oozie_node, task_id,
+                 trigger_rule=TriggerRule.ALL_SUCCESS, params={}, template='email.tpl'):
+        ActionMapper.__init__(self, oozie_node, task_id, trigger_rule)
+
+        self.template = template
+        self.params = params
+
+        # Parse required nodes first
+        self.check_required_nodes(oozie_node, REQ_NODES)
+        to = xml_utils.find_nodes_by_tag(oozie_node, TO_TAG)[0]
+        # to is a templated field in Apache Airflow 1.10.0, however requires a list
+        # so it is easier to just replace with variable.
+        self.to = el_utils.replace_el_with_var(to.text, params=self.params, quote=False)
+        self.to = self.to.split(',')
+
+        subject = xml_utils.find_nodes_by_tag(oozie_node, SUBJECT_TAG)[0]
+        # subject is a templated field in Apache Airflow 1.10.0
+        self.subject = el_utils.convert_el_to_jinja(subject.text, quote=True)
+
+        body = xml_utils.find_nodes_by_tag(oozie_node, BODY_TAG)[0]
+        # body is a templated field in Apache Airflow 1.10.0
+        self.body = el_utils.convert_el_to_jinja(body.text, quote=True)
+
+        # Onto parsing optional nodes
+        cc = xml_utils.find_nodes_by_tag(oozie_node, CC_TAG)
+        if cc:
+            self.cc = el_utils.replace_el_with_var(cc[0].text, params=self.params, quote=False)
+            # Split by comma into python list
+            self.cc = self.cc.split(",")
+
+        bcc = xml_utils.find_nodes_by_tag(oozie_node, BCC_TAG)
+        if bcc:
+            self.bcc = el_utils.replace_el_with_var(bcc[0].text, params=self.params, quote=False)
+            self.bcc = self.bcc.split(",")
+
+        content_type = xml_utils.find_nodes_by_tag(oozie_node, CONTENT_TAG)
+        if content_type:
+            # Don't quote this since the quote is already in the template (required by jinja default option)
+            self.content_type = el_utils.replace_el_with_var(content_type[0].text, params=self.params, quote=False)
+
+        attachment = xml_utils.find_nodes_by_tag(oozie_node, ATTACH_TAG)
+        if attachment:
+            self.attachment = el_utils.replace_el_with_var(attachment[0].text, params=self.params, quote=False)
+            self.attachment = self.attachment.split(",")
+
+    def convert_to_text(self):
+        template_loader = jinja2.FileSystemLoader(
+            searchpath=os.path.join(ROOT_DIR, 'templates/'))
+        template_env = jinja2.Environment(loader=template_loader)
+
+        template = template_env.get_template(self.template)
+        return template.render(**self.__dict__)
+
+    def convert_to_airflow_op(self):
+        return email_operator.EmailOperator(
+            task_id=self.task_id,
+            trigger_rule=self.trigger_rule,
+            params=self.params,
+            # Required for EmailOperator
+            to=self.to,
+            subject=self.subject,
+            html_content=self.body,
+            # Optional for EmailOperator
+            cc=self.cc or None,
+            bcc=self.bcc or None,
+            files=hdfs_helper_functions.read_hdfs_files(self.attachment) or None,
+            mime_subtype=self.content_type or MIXED,
+        )
+
+    def check_required_nodes(self, oozie_node, node_tag_list):
+        for tag in node_tag_list:
+            nodes = xml_utils.find_nodes_by_tag(oozie_node, tag)
+            if len(nodes) == 0:
+                logging.WARNING("Oozie Node {} missing"
+                                " required tag {}.".format(oozie_node.tag, tag))
+
+    @staticmethod
+    def required_imports():
+        return ['from airflow.operators import email_operator']

--- a/oozie-to-airflow/o2a_libs/hdfs_helper_functions.py
+++ b/oozie-to-airflow/o2a_libs/hdfs_helper_functions.py
@@ -1,0 +1,51 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# airflow DAG
+import io
+import logging
+import subprocess
+
+
+def read_hdfs_files(file_list):
+    """
+    Given a list of files, returns the corresponding list of StringIO objects
+    that represent the data from the HDFS file.
+
+    :param file_list: List of HDFS file names to be read.
+    :return: A list of StringIO objects corresponding to file_list
+    """
+    str_io_list = []
+
+    for f in file_list:
+        str_io_list.append(read_hdfs_file(f))
+
+    return str_io_list
+
+
+def read_hdfs_file(file_name):
+    """
+    Returns a StringIO object with the contents of:
+    `hadoop fs -cat FILE_NAME`
+
+    :param file_name: Name of file on HDFS, non fully-qualified path is
+        considered as a file on default HDFS
+    """
+    if file_name:
+        try:
+            output = subprocess.check_output(['hadoop', 'fs', '-cat', file_name])
+            return io.StringIO(output.decode('utf-8'))
+        except subprocess.SubprocessError:
+            logging.WARNING('Could not read file: {}'.format(file_name))
+

--- a/oozie-to-airflow/templates/email.tpl
+++ b/oozie-to-airflow/templates/email.tpl
@@ -1,0 +1,13 @@
+{{ task_id }} = email_operator.EmailOperator(
+    task_id='{{ task_id }}',
+    trigger_rule='{{ trigger_rule }}',
+    params=PARAMS,
+    to={{ to }},
+    subject={{ subject }},
+    html_content={{ body }},
+    cc={{ cc|default(None, true) }},
+    bcc={{ bcc|default(None, true) }},
+    mime_subtype='{{ content_type|default('mixed', true) }}',
+    files=read_hdfs_files({{ attachment|default([], true) }})
+)
+

--- a/oozie-to-airflow/tests/mappers/test_email_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_email_mapper.py
@@ -1,0 +1,168 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import unittest
+from unittest import mock
+from xml.etree import ElementTree as ET
+
+from airflow.utils.trigger_rule import TriggerRule
+
+from mappers import email_mapper
+
+
+class TestEmailMapper(unittest.TestCase):
+
+    def _create_xml_jinja(self):
+        email = ET.Element('email')
+        to = ET.SubElement(email, 'to')
+        cc = ET.SubElement(email, 'cc')
+        bcc = ET.SubElement(email, 'bcc')
+        subject = ET.SubElement(email, 'subject')
+        body = ET.SubElement(email, 'body')
+        content_type = ET.SubElement(email, 'content_type')
+        attachment = ET.SubElement(email, 'attachment')
+
+        to.text = '${to}'
+        cc.text = '${cc}'
+        bcc.text = '${bcc}'
+        subject.text = '${subject}'
+        body.text = '${body}'
+        content_type.text = '${content_type}'
+        attachment.text = '${attachment}'
+
+        self.et = ET.ElementTree(email)
+
+    def _create_xml_no_jinja(self):
+        email = ET.Element('email')
+        to = ET.SubElement(email, 'to')
+        cc = ET.SubElement(email, 'cc')
+        bcc = ET.SubElement(email, 'bcc')
+        subject = ET.SubElement(email, 'subject')
+        body = ET.SubElement(email, 'body')
+        content_type = ET.SubElement(email, 'content_type')
+        attachment = ET.SubElement(email, 'attachment')
+
+        to.text = 'bob@apache.org,not.bob@apache.org'
+        cc.text = 'john@apache.org,jeff@apache.org'
+        bcc.text = 'secret@apache.org,secret2@apache.org'
+        subject.text = 'test_subject'
+        body.text = 'this is a test body'
+        content_type.text = 'text/plain'
+        attachment.text = '/file/in/hdfs.txt'
+
+        self.et = ET.ElementTree(email)
+
+    def test_create_mapper_no_jinja(self):
+        self._create_xml_no_jinja()
+        mapper = email_mapper.EmailMapper(oozie_node=self.et.getroot(),
+                                          task_id='test_id',
+                                          trigger_rule=TriggerRule.DUMMY)
+        # make sure everything is getting initialized correctly
+        self.assertEqual('test_id', mapper.task_id)
+        self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
+        self.assertEqual(self.et.getroot(), mapper.oozie_node)
+
+        self.assertEqual(['bob@apache.org', 'not.bob@apache.org'], mapper.to)
+        self.assertEqual(['john@apache.org', 'jeff@apache.org'], mapper.cc)
+        self.assertEqual(['secret@apache.org', 'secret2@apache.org'],
+                         mapper.bcc)
+        self.assertEqual('\'test_subject\'', mapper.subject)
+        self.assertEqual('\'this is a test body\'', mapper.body)
+        self.assertEqual('text/plain', mapper.content_type)
+        self.assertEqual(['/file/in/hdfs.txt'], mapper.attachment)
+
+    def test_create_mapper_jinja(self):
+        self._create_xml_jinja()
+        # test jinja templating
+        params = {'to': 'user@apache.org,user2@apache.org',
+                  'cc': 'bob@apache.org',
+                  'bcc': 'jeff@apache.org',
+                  'subject': 'test_subject',
+                  'content_type': 'text/plain',
+                  'body': 'this is a test body',
+                  'attachment': '/file/in/hdfs.txt'}
+
+        mapper = email_mapper.EmailMapper(oozie_node=self.et.getroot(),
+                                          task_id='test_id',
+                                          trigger_rule=TriggerRule.DUMMY,
+                                          params=params)
+        self.assertEqual('test_id', mapper.task_id)
+        self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
+        self.assertEqual(self.et.getroot(), mapper.oozie_node)
+        # First two are parameterized in oozie
+        self.assertEqual('\'{{ params.subject }}\'', mapper.subject)
+        self.assertEqual('\'{{ params.body }}\'', mapper.body)
+        # Not parameterized so must replace variable with actual
+        self.assertEqual(['user@apache.org', 'user2@apache.org'], mapper.to)
+        self.assertEqual(['bob@apache.org'], mapper.cc)
+        self.assertEqual(['jeff@apache.org'], mapper.bcc)
+        self.assertEqual('text/plain', mapper.content_type)
+        self.assertEqual(['/file/in/hdfs.txt'], mapper.attachment)
+
+    def _create_xml_required(self):
+        email = ET.Element('email')
+        to = ET.SubElement(email, 'to')
+        subject = ET.SubElement(email, 'subject')
+        body = ET.SubElement(email, 'body')
+
+        to.text = 'bob@apache.org,not.bob@apache.org'
+        subject.text = 'test_subject'
+        body.text = 'this is a test body'
+
+        self.et = ET.ElementTree(email)
+
+    def test_convert_to_text(self):
+        self._create_xml_no_jinja()
+        mapper = email_mapper.EmailMapper(oozie_node=self.et.getroot(),
+                                          task_id='test_id',
+                                          trigger_rule=TriggerRule.DUMMY)
+        # Throws a syntax error if doesn't parse correctly
+        ast.parse(mapper.convert_to_text())
+
+    def test_convert_to_text_defaults(self):
+        self._create_xml_required()
+        mapper = email_mapper.EmailMapper(oozie_node=self.et.getroot(),
+                                          task_id='test_id',
+                                          trigger_rule=TriggerRule.DUMMY)
+        # Throws a syntax error if doesn't parse correctly
+        # This time the defaults are from email.tpl
+        ast.parse(mapper.convert_to_text())
+
+    @mock.patch('logging.WARNING')
+    def test_check_required_nodes(self, log_mock):
+        self._create_xml_required()
+        req_nodes = ['to', 'subject', 'body']
+        mapper = email_mapper.EmailMapper(oozie_node=self.et.getroot(),
+                                          task_id='test_id',
+                                          trigger_rule=TriggerRule.DUMMY)
+        mapper.check_required_nodes(mapper.oozie_node, req_nodes)
+        self.assertEqual(0, log_mock.call_count)
+
+    @mock.patch('logging.WARNING')
+    def test_check_required_nodes_missing(self, log_mock):
+        self._create_xml_required()
+        EXTRA_TAG = 'extra_tag'
+        req_nodes = ['to', 'subject', 'body', EXTRA_TAG]
+        mapper = email_mapper.EmailMapper(oozie_node=self.et.getroot(),
+                                          task_id='test_id',
+                                          trigger_rule=TriggerRule.DUMMY)
+        mapper.check_required_nodes(mapper.oozie_node, req_nodes)
+        log_mock.assert_called_once_with("Oozie Node {} missing"
+                                         " required tag {}.".format(mapper.oozie_node.tag, EXTRA_TAG))
+
+    def test_required_imports(self):
+        imps = email_mapper.EmailMapper.required_imports()
+        imp_str = '\n'.join(imps)
+        ast.parse(imp_str)

--- a/oozie-to-airflow/tests/o2a_libs/test_hdfs_helper_functions.py
+++ b/oozie-to-airflow/tests/o2a_libs/test_hdfs_helper_functions.py
@@ -1,0 +1,71 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+import unittest
+from unittest import mock
+
+from o2a_libs import hdfs_helper_functions
+
+
+class TestHelperFunctions(unittest.TestCase):
+
+    def test_read_hdfs_files_empty(self):
+        self.assertEqual([], hdfs_helper_functions.read_hdfs_files([]))
+
+    @mock.patch('subprocess.check_output')
+    def test_read_hdfs_files(self, check_mock):
+        OUTPUT = 'data'
+        check_mock.return_value = OUTPUT.encode('utf-8')
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="data")) as mock_file:
+            for f in hdfs_helper_functions.read_hdfs_files(['test.txt']):
+                self.assertEqual('data', f.read())
+                check_mock.assert_called_once_with(['hadoop', 'fs', '-cat', 'test.txt'])
+
+    @mock.patch('subprocess.check_output')
+    def test_read_hdfs_files_multiple(self, check_mock):
+        OUTPUT = 'data'
+        check_mock.return_value = OUTPUT.encode('utf-8')
+
+        with mock.patch("builtins.open", mock.mock_open(read_data="data")) as mock_file:
+            for f in hdfs_helper_functions.read_hdfs_files(['test.txt', 'test2.txt']):
+                self.assertEqual('data', f.read())
+                check_mock.assert_any_call(['hadoop', 'fs', '-cat', 'test.txt'])
+                check_mock.assert_any_call(['hadoop', 'fs', '-cat', 'test2.txt'])
+
+    @mock.patch('subprocess.check_output')
+    def test_read_hdfs_file(self, check_mock):
+        FN = 'test_file.txt'
+        OUTPUT = 'test output'
+
+        check_mock.return_value = OUTPUT.encode('utf-8')
+
+        actual = hdfs_helper_functions.read_hdfs_file(FN)
+
+        check_mock.assert_called_once_with(['hadoop', 'fs', '-cat', FN])
+        self.assertEqual(OUTPUT, actual.read())
+
+    @mock.patch('logging.WARNING')
+    @mock.patch('subprocess.check_output')
+    def test_read_hdfs_file_error(self, check_mock, log_mock):
+        FN = 'test_file.txt'
+        OUTPUT = 'test output'
+
+        check_mock.side_effect = subprocess.CalledProcessError(1, 'hadoop')
+        check_mock.return_value = OUTPUT.encode('utf-8')
+
+        actual = hdfs_helper_functions.read_hdfs_file(FN)
+
+        self.assertEqual(actual, None)
+        log_mock.assert_called_once()


### PR DESCRIPTION
1.) Adds support for parsing email oozie action nodes.
2.) Adds tests for EmailMapper
3.) Adds EmailMapper example
4.) Adds new o2a_libs, 'hdfs_helper_functions.py' required by the email mapper.