### PR TITLE
Add FS mapper

### DIFF
--- a/oozie-to-airflow/converter/exceptions.py
+++ b/oozie-to-airflow/converter/exceptions.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Custom exceptions"""
+
+
+class O2AException(Exception):
+    """Base class for all exceptions raised by Oozie-to-Airflow."""
+
+
+class ParseException(O2AException):
+    """Raised when an error occurs in the parsing phase."""

--- a/oozie-to-airflow/converter/mappers.py
+++ b/oozie-to-airflow/converter/mappers.py
@@ -26,6 +26,7 @@ from mappers.base_mapper import BaseMapper
 from mappers.decision_mapper import DecisionMapper
 from mappers.dummy_mapper import DummyMapper
 from mappers.end_mapper import EndMapper
+from mappers.fs_mapper import FsMapper
 from mappers.kill_mapper import KillMapper
 from mappers.mapreduce_mapper import MapReduceMapper
 from mappers.pig_mapper import PigMapper
@@ -50,6 +51,7 @@ ACTION_MAP: Dict[str, Type[ActionMapper]] = {
     "ssh": SSHMapper,
     "spark": SparkMapper,
     "pig": PigMapper,
+    "fs": FsMapper,
     "sub-workflow": SubworkflowMapper,
     "shell": ShellMapper,
     "map-reduce": MapReduceMapper,

--- a/oozie-to-airflow/converter/primitives.py
+++ b/oozie-to-airflow/converter/primitives.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 """Class for Airflow relation"""
 from collections import OrderedDict
-from typing import Set, Optional, Dict, NamedTuple
+from typing import Set, Optional, Dict, NamedTuple, Any
 
 # Pylint and flake8 does not understand forward references
 # https://www.python.org/dev/peps/pep-0484/#forward-references
 from converter import parsed_node  # noqa: F401 pylint: disable=unused-import
+from utils.template_utils import render_template
 
 
 class Relation(NamedTuple):
@@ -55,6 +56,7 @@ class Workflow:  # pylint: disable=too-few-public-methods
             "from airflow.utils.trigger_rule import TriggerRule",
             "from o2a_libs.el_basic_functions import * ",
             "from o2a_libs.el_wf_functions import * ",
+            "from airflow.utils import dates",
         }
 
     def __repr__(self) -> str:
@@ -62,4 +64,26 @@ class Workflow:  # pylint: disable=too-few-public-methods
             f"Workflow(dag_name={self.dag_name}, input_directory_path={self.input_directory_path}, "
             f"output_directory_path={self.output_directory_path}, relations={self.relations}, "
             f"nodes={self.nodes.keys()}, dependencies={self.dependencies})"
+        )
+
+
+# This is a container for data, so it does not contain public methods intentionally.
+class Task:  # pylint: disable=too-few-public-methods
+    task_id: str
+    template_name: str
+    template_params: Dict[str, Any]
+
+    def __init__(self, task_id, template_name, template_params=None):
+        self.task_id = task_id
+        self.template_name = template_name
+        self.template_params = template_params or {}
+
+    @property
+    def rendered_template(self):
+        return render_template(template_name=self.template_name, **self.template_params)
+
+    def __repr__(self) -> str:
+        return (
+            f"Task(task_id={self.task_id}, template_name={self.template_name}, "
+            f"template_params={self.template_params})"
         )

--- a/oozie-to-airflow/examples/fs/configuration.template.properties
+++ b/oozie-to-airflow/examples/fs/configuration.template.properties
@@ -1,0 +1,36 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dataproc_cluster={{DATAPROC_CLUSTER_NAME}}
+gcp_conn_id=google_cloud_default
+gcp_region={{GCP_REGION}}
+gcp_uri_prefix=gs://{{COMPOSER_DAG_BUCKET}}/dags

--- a/oozie-to-airflow/examples/fs/job.properties
+++ b/oozie-to-airflow/examples/fs/job.properties
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nameNode=hdfs://localhost:8020
+resourceManager=localhost:8032
+queueName=default
+examplesRoot=examples
+
+oozie.wf.application.path=${nameNode}/user/${user.name}/${examplesRoot}/apps/shell

--- a/oozie-to-airflow/examples/fs/workflow.xml
+++ b/oozie-to-airflow/examples/fs/workflow.xml
@@ -1,0 +1,85 @@
+<!--
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ -->
+
+<workflow-app xmlns="uri:oozie:workflow:1.0" name="fs-wf">
+    <start to="fs-node"/>
+    <fork name="fs-node">
+        <path start="mkdir"/>
+        <path start="delete"/>
+        <path start="move"/>
+        <path start="chmod"/>
+        <path start="touchz"/>
+        <path start="chgrp"/>
+    </fork>
+    <action name="mkdir">
+        <fs>
+            <mkdir path='${nameNode}/user/fs/examples/test-mkdir-1'/>
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+    <action name="delete">
+        <fs>
+            <mkdir path='${nameNode}/user/fs/examples/test-delete-1'/>
+            <delete path='${nameNode}/user/fs/examples/test-delete-1'/>
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+    <action name="move">
+        <fs>
+            <mkdir path='${nameNode}/user/fs/examples/test-move-1'/>
+            <move source='${nameNode}/user/fs/examples/test-move-1' target='/user/fs/examples/test-move-2' />
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+    <action name="chmod">
+        <fs>
+            <mkdir path='${nameNode}/user/fs/examples/test-chmod-1'/>
+            <mkdir path='${nameNode}/user/fs/examples/test-chmod-2'/>
+            <mkdir path='${nameNode}/user/fs/examples/test-chmod-3'/>
+            <mkdir path='${nameNode}/user/fs/examples/test-chmod-4'/>
+            <chmod path='${nameNode}/user/fs/examples/test-chmod-1' permissions='777' dir-files='false' />
+            <chmod path='${nameNode}/user/fs/examples/test-chmod-2' permissions='777' dir-files='true' />
+            <chmod path='${nameNode}/user/fs/examples/test-chmod-3' permissions='777' />
+            <chmod path='${nameNode}/user/fs/examples/test-chmod-4' permissions='777' dir-files='false' >
+                <recursive/>
+            </chmod>
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+    <action name="touchz">
+        <fs>
+            <touchz path='${nameNode}/user/fs/examples/test-touchz-1' />
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+    <action name="chgrp">
+        <fs>
+            <mkdir path='${nameNode}/user/fs/examples/test-chgrp-1'/>
+            <chgrp path='${nameNode}/user/fs/examples/test-chgrp-1' group='hadoop' />
+        </fs>
+        <ok to="end"/>
+        <error to="fail"/>
+    </action>
+    <kill name="fail">
+        <message>Fs workflow failed, error message[${wf:errorMessage(wf:lastErrorNode())}]</message>
+    </kill>
+    <end name="end"/>
+</workflow-app>

--- a/oozie-to-airflow/examples/pig/workflow.xml
+++ b/oozie-to-airflow/examples/pig/workflow.xml
@@ -40,8 +40,8 @@
             <resource-manager>${resourceManager}</resource-manager>
             <name-node>${nameNode}</name-node>
             <prepare>
-                <delete path="/user/pig/examples/test_pig_node/output-data"/>
-                <mkdir path="/user/pig/examples/test_pig_node/created-folder"/>
+                <delete path="${nameNode}/user/pig/examples/test_pig_node/output-data"/>
+                <mkdir path="${nameNode}/user/pig/examples/test_pig_node/created-folder"/>
             </prepare>
             <configuration>
                 <property>

--- a/oozie-to-airflow/mappers/fs_mapper.py
+++ b/oozie-to-airflow/mappers/fs_mapper.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Maps FS node to Airflow's DAG"""
+
+import shlex
+from typing import Set, List
+from xml.etree.ElementTree import Element
+
+from converter.primitives import Task
+from mappers.action_mapper import ActionMapper
+from utils.relation_utils import chain
+from utils.template_utils import render_template
+from utils.el_utils import normalize_path
+
+ACTION_TYPE = "fs"
+
+FS_OP_MKDIR = "mkdir"
+FS_OP_DELETE = "delete"
+FS_OP_MOVE = "move"
+FS_OP_CHMOD = "chmod"
+FS_OP_TOUCHZ = "touchz"
+FS_OP_CHGRP = "chgrp"
+
+FS_TAG_PATH = "path"
+FS_TAG_SOURCE = "source"
+FS_TAG_TARGET = "target"
+FS_TAG_RECURSIVE = "recursive"
+FS_TAG_DIRFILES = "dir-files"
+FS_TAG_PERMISSIONS = "permissions"
+FS_TAG_GROUP = "group"
+
+
+def prepare_mkdir_command(node: Element, params):
+    path = normalize_path(node.attrib[FS_TAG_PATH], params)
+    command = "fs -mkdir {path}".format(path=shlex.quote(path))
+    return command
+
+
+def prepare_delete_command(node: Element, params):
+    path = normalize_path(node.attrib[FS_TAG_PATH], params)
+    command = "fs -rm -r {path}".format(path=shlex.quote(path))
+
+    return command
+
+
+def prepare_move_command(node: Element, params):
+    source = normalize_path(node.attrib[FS_TAG_SOURCE], params)
+    target = normalize_path(node.attrib[FS_TAG_TARGET], params, allow_no_schema=True)
+
+    command = "fs -mv {source} {target}".format(source=source, target=target)
+    return command
+
+
+def prepare_chmod_command(node: Element, params):
+    path = normalize_path(node.attrib[FS_TAG_PATH], params)
+    permission = node.attrib[FS_TAG_PERMISSIONS]
+    # TODO: Add support for dirFiles Reference: GH issues #80
+    # dirFiles = bool_value(node, FS_TAG _DIRFILES)
+    recursive = node.find(FS_TAG_RECURSIVE) is not None
+    extra_param = "-R" if recursive else ""
+
+    command = "fs -chmod {extra} {permission} {path}".format(
+        extra=extra_param, path=shlex.quote(path), permission=shlex.quote(permission)
+    )
+    return command
+
+
+def prepare_touchz_command(node: Element, params):
+    path = normalize_path(node.attrib[FS_TAG_PATH], params)
+
+    command = "fs -touchz {path}".format(path=shlex.quote(path))
+    return command
+
+
+def prepare_chgrp_command(node: Element, params):
+    path = normalize_path(node.attrib[FS_TAG_PATH], params)
+    group = node.attrib[FS_TAG_GROUP]
+
+    recursive = node.find(FS_TAG_RECURSIVE) is not None
+    extra_param = "-R" if recursive else ""
+
+    command = "fs -chgrp {extra} {group} {path}".format(
+        extra=extra_param, group=shlex.quote(group), path=shlex.quote(path)
+    )
+    return command
+
+
+FS_OPERATION_MAPPERS = {
+    FS_OP_MKDIR: prepare_mkdir_command,
+    FS_OP_DELETE: prepare_delete_command,
+    FS_OP_MOVE: prepare_move_command,
+    FS_OP_CHMOD: prepare_chmod_command,
+    FS_OP_TOUCHZ: prepare_touchz_command,
+    FS_OP_CHGRP: prepare_chgrp_command,
+}
+
+
+class FsMapper(ActionMapper):
+    """
+    Converts a FS Oozie node to an Airflow task.
+    """
+
+    tasks: List[Task]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tasks = []
+
+    def on_parse_node(self):
+        super().on_parse_node()
+        self.tasks = self.parse_tasks()
+
+    def parse_tasks(self):
+        if not list(self.oozie_node):
+            return [
+                Task(
+                    task_id=self.name,
+                    template_name="dummy.tpl",
+                    template_params=dict(task_id=self.name, trigger_rule=self.trigger_rule),
+                )
+            ]
+
+        return [self.parse_fs_action(i, node) for i, node in enumerate(self.oozie_node)]
+
+    def convert_to_text(self):
+        return render_template(
+            template_name="fs.tpl",
+            task_id=self.name,
+            trigger_rule=self.trigger_rule,
+            sub_ops=self.tasks,
+            relations=chain(self.tasks),
+        )
+
+    @staticmethod
+    def required_imports() -> Set[str]:
+        return {
+            "from airflow.operators import dummy_operator",
+            "from airflow.operators import bash_operator",
+            "import shlex",
+        }
+
+    @property
+    def first_task_id(self):
+        return self.tasks[0].task_id
+
+    @property
+    def last_task_id(self):
+        return self.tasks[-1].task_id
+
+    def parse_fs_action(self, index: int, node: Element):
+        tag_name = node.tag
+        tasks_count = len(self.oozie_node)
+        task_id = self.name if tasks_count == 1 else f"{self.name}_fs_{index}_{tag_name}"
+        mapper_fn = FS_OPERATION_MAPPERS.get(tag_name)
+
+        if not mapper_fn:
+            raise Exception("Unknown FS operation: {}".format(tag_name))
+
+        pig_command = mapper_fn(node, self.params)
+
+        return Task(
+            task_id=task_id,
+            template_name="fs_op.tpl",
+            template_params=dict(task_id=task_id, pig_command=pig_command),
+        )

--- a/oozie-to-airflow/mappers/prepare_mixin.py
+++ b/oozie-to-airflow/mappers/prepare_mixin.py
@@ -16,7 +16,8 @@
 from typing import Dict, List, Tuple
 import xml.etree.ElementTree as ET
 
-from utils import xml_utils, el_utils
+from utils import xml_utils
+from utils.el_utils import normalize_path
 
 
 class PrepareMixin:
@@ -55,10 +56,7 @@ class PrepareMixin:
             # If there exists a prepare node, there will only be one, according
             # to oozie xml schema
             for node in prepare_nodes[0]:
-                node_path = el_utils.replace_el_with_var(node.attrib["path"], params=params, quote=False)
-                if "//" in node_path:
-                    node_path = node_path.split("//", maxsplit=1)[1]  # Removing the hdfs:// or similar part
-                node_path = "/" + node_path.split("/", maxsplit=1)[1]  # Removing the 'localhost:8082/' part
+                node_path = normalize_path(node.attrib["path"], params=params)
                 if node.tag == "delete":
                     delete_paths.append(node_path)
                 else:

--- a/oozie-to-airflow/templates/fs.tpl
+++ b/oozie-to-airflow/templates/fs.tpl
@@ -1,0 +1,21 @@
+{#
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ #}
+{% for op in sub_ops %}
+{{ op.rendered_template }}
+{% endfor %}
+{% with relations=relations %}
+    {% include "relations.tpl" %}
+{% endwith %}

--- a/oozie-to-airflow/templates/fs_op.tpl
+++ b/oozie-to-airflow/templates/fs_op.tpl
@@ -1,0 +1,19 @@
+{#
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ #}
+{{ task_id }} = bash_operator.BashOperator(
+    bash_command="gcloud dataproc jobs submit pig --cluster={dataproc_cluster} --region={gcp_region} --execute {bash_command}".format(dataproc_cluster=PARAMS['dataproc_cluster'], gcp_region=PARAMS['gcp_region'], bash_command=shlex.quote("{{ pig_command }}")),
+    task_id='{{ task_id }}',
+)

--- a/oozie-to-airflow/tests/converter/test_oozie_parser.py
+++ b/oozie-to-airflow/tests/converter/test_oozie_parser.py
@@ -449,6 +449,21 @@ class TestOozieExamples(unittest.TestCase):
             ),
             (
                 WorkflowTestCase(
+                    name="fs",
+                    node_names={"chmod", "mkdir", "fs_node", "delete", "move", "touchz", "chgrp"},
+                    relations={
+                        Relation(from_task_id="fs_node", to_task_id="chgrp_fs_0_mkdir"),
+                        Relation(from_task_id="fs_node", to_task_id="delete_fs_0_mkdir"),
+                        Relation(from_task_id="fs_node", to_task_id="chmod_fs_0_mkdir"),
+                        Relation(from_task_id="fs_node", to_task_id="touchz"),
+                        Relation(from_task_id="fs_node", to_task_id="mkdir"),
+                        Relation(from_task_id="fs_node", to_task_id="move_fs_0_mkdir"),
+                    },
+                    params={"hostname": "AAAA@BBB", "nameNode": "hdfs://localhost:8020/"},
+                ),
+            ),
+            (
+                WorkflowTestCase(
                     name="pig",
                     node_names={"pig_node"},
                     relations=set(),

--- a/oozie-to-airflow/tests/mappers/test_fs_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_fs_mapper.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests fs mapper"""
+
+import ast
+import unittest
+from xml.etree import ElementTree as ET
+
+from parameterized import parameterized
+from airflow.utils.trigger_rule import TriggerRule
+
+from mappers import fs_mapper
+
+TEST_PARAMS = {"user.name": "pig", "nameNode": "hdfs://localhost:8020"}
+
+
+# pylint: disable=invalid-name
+class prepare_mkdir_commandTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "<mkdir path='hdfs://localhost:8020/home/pig/test-fs/test-mkdir-1'/>",
+                "fs -mkdir /home/pig/test-fs/test-mkdir-1",
+            ),
+            (
+                "<mkdir path='${nameNode}/home/pig/test-fs/DDD-mkdir-1'/>",
+                "fs -mkdir /home/pig/test-fs/DDD-mkdir-1",
+            ),
+        ]
+    )
+    def test_result(self, xml, command):
+        node = ET.fromstring(xml)
+        self.assertEqual(fs_mapper.prepare_mkdir_command(node, TEST_PARAMS), command)
+
+
+class prepare_delete_commandTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "<delete path='hdfs://localhost:8020/home/pig/test-fsXXX/test-delete-3'/>",
+                "fs -rm -r /home/pig/test-fsXXX/test-delete-3",
+            ),
+            (
+                "<delete path='hdfs://localhost:8020/home/pig/test-fs/test-delete-3'/>",
+                "fs -rm -r /home/pig/test-fs/test-delete-3",
+            ),
+        ]
+    )
+    def test_result(self, xml, command):
+        node = ET.fromstring(xml)
+        self.assertEqual(fs_mapper.prepare_delete_command(node, TEST_PARAMS), command)
+
+
+class prepare_move_commanddTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "<move source='hdfs://localhost:8020/home/pig/test-fs/test-move-1' "
+                "target='/home/pig/test-fs/test-move-2' />",
+                "fs -mv /home/pig/test-fs/test-move-1 /home/pig/test-fs/test-move-2",
+            ),
+            (
+                "<move source='${nameNode}/home/pig/test-fs/test-move-1' "
+                "target='/home/pig/test-DDD/test-move-2' />",
+                "fs -mv /home/pig/test-fs/test-move-1 /home/pig/test-DDD/test-move-2",
+            ),
+            (
+                "<move source='${nameNode}/home/pig/test-fs/test-move-1' "
+                "target='/home/pig/test-DDD/test-move-2' />",
+                "fs -mv /home/pig/test-fs/test-move-1 /home/pig/test-DDD/test-move-2",
+            ),
+        ]
+    )
+    def test_result(self, xml, command):
+        node = ET.fromstring(xml)
+        self.assertEqual(fs_mapper.prepare_move_command(node, TEST_PARAMS), command)
+
+
+class prepare_chmod_commandTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "<chmod path='hdfs://localhost:8020/home/pig/test-fs/test-chmod-1' "
+                "permissions='777' dir-files='false' />",
+                "fs -chmod  777 /home/pig/test-fs/test-chmod-1",
+            ),
+            (
+                "<chmod path='hdfs://localhost:8020/home/pig/test-fs/test-chmod-2' "
+                "permissions='777' dir-files='true' />",
+                "fs -chmod  777 /home/pig/test-fs/test-chmod-2",
+            ),
+            (
+                "<chmod path='${nameNode}/home/pig/test-fs/test-chmod-3' permissions='777' />",
+                "fs -chmod  777 /home/pig/test-fs/test-chmod-3",
+            ),
+            (
+                """<chmod path='hdfs://localhost:8020/home/pig/test-fs/test-chmod-4'
+                permissions='777' dir-files='false' >
+         <recursive/>
+         </chmod>""",
+                "fs -chmod -R 777 /home/pig/test-fs/test-chmod-4",
+            ),
+        ]
+    )
+    def test_result(self, xml, command):
+        node = ET.fromstring(xml)
+        self.assertEqual(fs_mapper.prepare_chmod_command(node, TEST_PARAMS), command)
+
+
+class prepare_touchz_commandTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "<touchz path='hdfs://localhost:8020/home/pig/test-fs/test-touchz-1' />",
+                "fs -touchz /home/pig/test-fs/test-touchz-1",
+            ),
+            (
+                "<touchz path='${nameNode}/home/pig/test-fs/DDDD-touchz-1' />",
+                "fs -touchz /home/pig/test-fs/DDDD-touchz-1",
+            ),
+        ]
+    )
+    def test_result(self, xml, command):
+        node = ET.fromstring(xml)
+        self.assertEqual(fs_mapper.prepare_touchz_command(node, TEST_PARAMS), command)
+
+
+class prepare_chgrp_commandTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "<chgrp path='hdfs://localhost:8020/home/pig/test-fs/test-chgrp-1' group='hadoop' />",
+                "fs -chgrp  hadoop /home/pig/test-fs/test-chgrp-1",
+            ),
+            (
+                "<chgrp path='${nameNode}0/home/pig/test-fs/DDD-chgrp-1' group='hadoop' />",
+                "fs -chgrp  hadoop /home/pig/test-fs/DDD-chgrp-1",
+            ),
+        ]
+    )
+    def test_result(self, xml, command):
+        node = ET.fromstring(xml)
+        self.assertEqual(fs_mapper.prepare_chgrp_command(node, TEST_PARAMS), command)
+
+
+class FsMapperSingleTestCase(unittest.TestCase):
+    def setUp(self):
+        # language=XML
+        node_str = """
+            <fs>
+                <mkdir path='hdfs://localhost:9200/home/pig/test-delete-1'/>
+            </fs>"""
+        self.node = ET.fromstring(node_str)
+
+        self.mapper = fs_mapper.FsMapper(oozie_node=self.node, name="test_id", trigger_rule=TriggerRule.DUMMY)
+        self.mapper.on_parse_node()
+
+    def test_convert_to_text(self):
+        # Throws a syntax error if doesn't parse correctly
+        self.assertIsNotNone(ast.parse(self.mapper.convert_to_text()))
+
+    def test_required_imports(self):
+        imps = fs_mapper.FsMapper.required_imports()
+        imp_str = "\n".join(imps)
+        self.assertIsNotNone(ast.parse(imp_str))
+
+    def test_get_first_task_id(self):
+        self.assertEqual(self.mapper.first_task_id, "test_id")
+
+    def test_get_last_task_id(self):
+        self.assertEqual(self.mapper.last_task_id, "test_id")
+
+
+class FsMapperEmptyTestCase(unittest.TestCase):
+    def setUp(self):
+        self.node = ET.Element("fs")
+        self.mapper = fs_mapper.FsMapper(oozie_node=self.node, name="test_id", trigger_rule=TriggerRule.DUMMY)
+        self.mapper.on_parse_node()
+
+    def test_convert_to_text(self):
+        # Throws a syntax error if doesn't parse correctly
+        self.assertIsNotNone(ast.parse(self.mapper.convert_to_text()))
+
+    def test_required_imports(self):
+        imps = fs_mapper.FsMapper.required_imports()
+        imp_str = "\n".join(imps)
+        self.assertIsNotNone(ast.parse(imp_str))
+
+    def test_get_first_task_id(self):
+        self.assertEqual(self.mapper.first_task_id, "test_id")
+
+    def test_get_last_task_id(self):
+        self.assertEqual(self.mapper.last_task_id, "test_id")
+
+
+class FsMapperComplexTestCase(unittest.TestCase):
+    def setUp(self):
+        # language=XML
+        node_str = """
+            <fs>
+                <!-- mkdir -->
+                <mkdir path='hdfs://localhost:9200/home/pig/test-delete-1'/>
+                <mkdir path='hdfs:///home/pig/test-delete-2'/>
+                <!-- delete -->
+                <mkdir path='hdfs://localhost:9200/home/pig/test-delete-1'/>
+                <mkdir path='hdfs://localhost:9200/home/pig/test-delete-2'/>
+                <mkdir path='hdfs://localhost:9200/home/pig/test-delete-3'/>
+                <delete path='hdfs://localhost:9200/home/pig/test-delete-1'/>
+
+                <!-- move -->
+                <mkdir path='hdfs://localhost:9200/home/pig/test-delete-1'/>
+                <move source='hdfs://localhost:9200/home/pig/test-chmod-1' target='/home/pig/test-chmod-2' />
+
+                <!-- chmod -->
+                <mkdir path='hdfs://localhost:9200/home/pig/test-chmod-1'/>
+                <mkdir path='hdfs://localhost:9200/home/pig/test-chmod-2'/>
+                <mkdir path='hdfs://localhost:9200/home/pig/test-chmod-3'/>
+                <mkdir path='hdfs://localhost:9200/home/pig/test-chmod-4'/>
+                <chmod path='hdfs://localhost:9200/home/pig/test-chmod-1'
+                    permissions='-rwxrw-rw-' dir-files='false' />
+                <chmod path='hdfs://localhost:9200/home/pig/test-chmod-2'
+                    permissions='-rwxrw-rw-' dir-files='true' />
+                <chmod path='hdfs://localhost:9200/home/pig/test-chmod-3'
+                    permissions='-rwxrw-rw-' />
+                <chmod path='hdfs://localhost:9200/home/pig/test-chmod-4'
+                    permissions='-rwxrw-rw-' dir-files='false' >
+                    <recursive/>
+                </chmod>
+
+                <!-- touchz -->
+                <touchz path='hdfs://localhost:9200/home/pig/test-touchz-1' />
+
+                <!-- chgrp -->
+                <chgrp path='hdfs://localhost:9200/home/pig/test-touchz-1' group='pig' />
+            </fs>"""
+        self.node = ET.fromstring(node_str)
+
+        self.mapper = fs_mapper.FsMapper(oozie_node=self.node, name="test_id", trigger_rule=TriggerRule.DUMMY)
+        self.mapper.on_parse_node()
+
+    def test_convert_to_text(self):
+        # Throws a syntax error if doesn't parse correctly
+        self.assertIsNotNone(ast.parse(self.mapper.convert_to_text()))
+
+    def test_required_imports(self):
+        imps = fs_mapper.FsMapper.required_imports()
+        imp_str = "\n".join(imps)
+        self.assertIsNotNone(ast.parse(imp_str))
+
+    def test_get_first_task_id(self):
+        self.assertEqual(self.mapper.first_task_id, "test_id_fs_0_mkdir")
+
+    def test_get_last_task_id(self):
+        self.assertEqual(self.mapper.last_task_id, "test_id_fs_17_chgrp")

--- a/oozie-to-airflow/tests/mappers/test_mapreduce_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_mapreduce_mapper.py
@@ -124,9 +124,10 @@ class TestMapReduceMapper(unittest.TestCase):
             name="test_id",
             trigger_rule=TriggerRule.DUMMY,
             params={
+                "nameNode": "hdfs://",
                 "dataproc_cluster": "my-cluster",
                 "gcp_region": "europe-west3",
-                "hadoop_jars": "hdfs:/user/mapred/examples/mapreduce/lib/wordcount.jar",
+                "hadoop_jars": "hdfs:///user/mapred/examples/mapreduce/lib/wordcount.jar",
                 "hadoop_main_class": "WordCount",
             },
         )

--- a/oozie-to-airflow/tests/mappers/test_prepare_mixin.py
+++ b/oozie-to-airflow/tests/mappers/test_prepare_mixin.py
@@ -28,6 +28,7 @@ class TestPrepareMixin(unittest.TestCase):
     def test_with_prepare(self):
         cluster = "my-cluster"
         region = "europe-west3"
+        params = {"nameNode": "hdfs://localhost:8020", "dataproc_cluster": cluster, "gcp_region": region}
         # language=XML
         pig_node_prepare_str = """
 <pig>
@@ -41,9 +42,8 @@ class TestPrepareMixin(unittest.TestCase):
 </pig>
 """
         pig_node_prepare = ET.fromstring(pig_node_prepare_str)
-        prepare = prepare_mixin.PrepareMixin().get_prepare_command(
-            oozie_node=pig_node_prepare, params={"dataproc_cluster": cluster, "gcp_region": region}
-        )
+
+        prepare = prepare_mixin.PrepareMixin().get_prepare_command(oozie_node=pig_node_prepare, params=params)
         self.assertEqual(
             '$DAGS_FOLDER/../data/prepare.sh -c {0} -r {1} -d "{2} {3}" -m "{4} {5}"'.format(
                 cluster, region, self.delete_path1, self.delete_path2, self.mkdir_path1, self.mkdir_path2
@@ -54,10 +54,9 @@ class TestPrepareMixin(unittest.TestCase):
     def test_no_prepare(self):
         cluster = "my-cluster"
         region = "europe-west3"
+        params = {"nameNode": "hdfs://localhost:8020", "dataproc_cluster": cluster, "gcp_region": region}
         # language=XML
         pig_node_str = "<pig><name-node>hdfs://</name-node></pig>"
         pig_node = ET.fromstring(pig_node_str)
-        prepare = prepare_mixin.PrepareMixin().get_prepare_command(
-            oozie_node=pig_node, params={"dataproc_cluster": cluster, "gcp_region": region}
-        )
+        prepare = prepare_mixin.PrepareMixin().get_prepare_command(oozie_node=pig_node, params=params)
         self.assertEqual("", prepare)

--- a/oozie-to-airflow/tests/mappers/test_shell_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_shell_mapper.py
@@ -93,7 +93,11 @@ class TestShellMapper(unittest.TestCase):
             oozie_node=self.shell_node,
             name="test_id",
             trigger_rule=TriggerRule.DUMMY,
-            params={"dataproc_cluster": "my-cluster", "gcp_region": "europe-west3"},
+            params={
+                "dataproc_cluster": "my-cluster",
+                "gcp_region": "europe-west3",
+                "nameNode": "hdfs://localhost:9020/",
+            },
         )
         # Throws a syntax error if doesn't parse correctly
         ast.parse(mapper.convert_to_text())

--- a/oozie-to-airflow/tests/utils/test_relation_utils.py
+++ b/oozie-to-airflow/tests/utils/test_relation_utils.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests Relation utils"""
+import unittest
+
+from converter.primitives import Task, Relation
+from mappers import fs_mapper
+
+
+# pylint: disable=invalid-name
+class chainTestCase(unittest.TestCase):
+    def test_empty(self):
+        relations = fs_mapper.chain([])
+        self.assertEqual(relations, [])
+
+    def test_one(self):
+        relations = fs_mapper.chain([Task(task_id="A", template_name="")])
+        self.assertEqual(relations, [])
+
+    def test_multiple(self):
+        relations = fs_mapper.chain(
+            [
+                fs_mapper.Task(task_id="task_1", template_name=""),
+                fs_mapper.Task(task_id="task_2", template_name=""),
+                fs_mapper.Task(task_id="task_3", template_name=""),
+                fs_mapper.Task(task_id="task_4", template_name=""),
+            ]
+        )
+        self.assertEqual(
+            relations,
+            [
+                Relation(from_task_id="task_1", to_task_id="task_2"),
+                Relation(from_task_id="task_2", to_task_id="task_3"),
+                Relation(from_task_id="task_3", to_task_id="task_4"),
+            ],
+        )

--- a/oozie-to-airflow/utils/relation_utils.py
+++ b/oozie-to-airflow/utils/relation_utils.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Relation utilities"""
+
+from typing import List, Sequence
+
+from converter.primitives import Relation, Task
+
+
+def chain(ops: Sequence[Task]) -> List[Relation]:
+    """
+    Given a number of tasks, builds a relation chain.
+
+    ** Example: **
+
+    :codeblock: pycon
+        >>> tasks = [
+        ...     Task(task_id="task_a", template_name="task_a.tpl"),
+        ...     Task(task_id="task_b", template_name="task_b.tpl"),
+        ...     Task(task_id="task_c", template_name="task_c.tpl")
+        ... ]
+        >>> chain(tasks)
+        [Relation(from_task_id='task_a', to_task_id='task_b'), Relation(from_task_id='task_b',
+        to_task_id='task_c')]
+
+    :param ops: sequence of tasks
+    :return: list of relations
+    """
+    return [Relation(from_task_id=a.task_id, to_task_id=b.task_id) for a, b in zip(ops, ops[1::])]

--- a/pylintrc
+++ b/pylintrc
@@ -143,6 +143,7 @@ disable=print-statement,
         logging-format-interpolation,
         logging-fstring-interpolation,
         import-error,
+        duplicate-code,
         fixme
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
Hello,

I implemented a FS mapper. Implantation does not support all functionalities (See: TODO notes) and it's not idempotent.  This is the limitation of pig commands.

It's not tested on Oozie.

Reference:
https://oozie.apache.org/docs/5.1.0/WorkflowFunctionalSpec.html#a3.2.4_Fs_HDFS_action

Visualisation of converted DAG:
![Screenshot 2019-04-19 at 01 01 02](https://user-images.githubusercontent.com/12058428/56396333-a5c29d00-623e-11e9-87c6-d3b30f7267e5.png)

Code of converted DAG:
https://gist.github.com/mik-laj/3e1f6137153825d7a4477c70ed1ee3c8

Code of workflow XML:
https://github.com/GoogleCloudPlatform/cloud-composer/blob/fs-mapper/oozie-to-airflow/examples/fs/workflow.xml


Greets