### PR TITLE
Scan only tests directory by pytest

### DIFF
--- a/oozie-to-airflow/run_tests.sh
+++ b/oozie-to-airflow/run_tests.sh
@@ -16,5 +16,5 @@ set -euo pipefail
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd ${MY_DIR}
-pytest
+pytest tests
 popd


### PR DESCRIPTION
Hello,

When I have a file in the project that is ignored, i.e. no part of the project, `pytest` touches it. Usually this is not a problem, but when the file is damaged it makes it difficult to work, because pytest reports an error.

Greets,