### PR TITLE
Add missing mock dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ black==19.3b0
 flake8==3.7.7
 google-api-python-client==1.7.8
 Jinja2==2.10.1
+mock==2.0.0
 mypy==0.700
 parameterized==0.7.0
 paramiko==2.4.2


### PR DESCRIPTION
There was a missing `mock` dependency to one of the previous PRs.