### PR TITLE
Fix mock import from unittest

### DIFF
--- a/oozie-to-airflow/tests/converter/test_parsed_node.py
+++ b/oozie-to-airflow/tests/converter/test_parsed_node.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 """Tests parsed node"""
 import unittest
+from unittest import mock
 from xml.etree.ElementTree import Element
 
-import mock
 from airflow.utils.trigger_rule import TriggerRule
 
 from converter import parsed_node


### PR DESCRIPTION
Change the import syntax for `mock` in `test_parsed_node.py` (the previous version caused errors in IDE and in the pre-commit hook).