### PR TITLE
Fix file and archive functionality

### DIFF
--- a/oozie-to-airflow/converter/parser.py
+++ b/oozie-to-airflow/converter/parser.py
@@ -196,14 +196,15 @@ class OozieParser:
         """
         # The 0th element of the node is the actual action tag.
         # In the form of 'action'
-        action_name = action_node[0].tag
+        action_operation_node = action_node[0]
+        action_name = action_operation_node.tag
 
         if action_name not in self.action_map:
             action_name = "unknown"
 
         map_class = self.action_map[action_name]
         mapper = map_class(
-            oozie_node=action_node[0],
+            oozie_node=action_operation_node,
             name=action_node.attrib["name"],
             params=self.params,
             dag_name=self.workflow.dag_name,

--- a/oozie-to-airflow/examples/pig/workflow.xml
+++ b/oozie-to-airflow/examples/pig/workflow.xml
@@ -56,11 +56,11 @@
             <script>id.pig</script>
             <param>INPUT=/user/pig/examples/test_pig_node/input-data/test-data.txt</param>
             <param>OUTPUT=/user/pig/examples/test_pig_node/output-data</param>
+            <file>test_dir/test.txt#test_link.txt</file>
+            <file>/user/pig/examples/test_pig_node/test_dir/test2.zip#test_link.zip</file>
+            <archive>test_dir/test2.zip#test_zip_dir</archive>
+            <archive>test_dir/test3.zip#test3_zip_dir</archive>
         </pig>
-        <file>test_dir/test.txt#test_link.txt</file>
-        <file>/user/pig/examples/test_pig_node/test_dir/test2.zip#test_link.zip</file>
-        <archive>test_dir/test2.zip#test_zip_dir</archive>
-        <archive>test_dir/test3.zip#test3_zip_dir</archive>
         <ok to="end"/>
         <error to="fail"/>
     </action>

--- a/oozie-to-airflow/mappers/__init__.py
+++ b/oozie-to-airflow/mappers/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
     "base_mapper",
     "decision_mapper",
     "dummy_mapper",
-    "file_archive_mixins",
+    "file_archive_mappers",
     "kill_mapper",
     "null_mapper",
     "pig_mapper",

--- a/oozie-to-airflow/mappers/file_archive_mappers.py
+++ b/oozie-to-airflow/mappers/file_archive_mappers.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Mixins for File and Archives"""
+"""Mapper for File and Archive nodes"""
 from typing import Dict, List
+from xml.etree.ElementTree import Element
 
 
 class HdfsPathProcessor:
@@ -50,22 +51,23 @@ def split_by_hash_sign(path: str) -> List[str]:
     return [path]
 
 
-# pylint: disable=too-few-public-methods
-class FileMixin:
-    """Mixin for file node"""
+class FileMapper:
+    """ Converts a file oozie node """
 
-    def __init__(self, params: Dict[str, str]):
+    def __init__(self, oozie_node: Element, params: Dict[str, str]):
         self.files = ""
         self.hdfs_files = ""
         self.file_path_processor = HdfsPathProcessor(params=params)
+        self.oozie_node = oozie_node
 
-    def on_parse_node(self):
-        super().on_parse_node()
+    def parse_node(self):
         file_nodes = self.oozie_node.findall("file")
 
         for file_node in file_nodes:
             file_path = file_node.text
             self.add_file(file_path)
+
+        return self.files, self.hdfs_files
 
     def add_file(self, oozie_file_path: str) -> None:
         """
@@ -84,24 +86,24 @@ class FileMixin:
         )
 
 
-# pylint: disable=too-few-public-methods
-class ArchiveMixin:
-    """Mixin for archive node"""
+class ArchiveMapper:
+    """ Converts an archive oozie node """
 
     ALLOWED_EXTENSIONS = [".zip", ".gz", ".tar.gz", ".tar", ".jar"]
 
-    def __init__(self, params: Dict[str, str]):
+    def __init__(self, oozie_node: Element, params: Dict[str, str]):
         self.archives = ""
         self.hdfs_archives = ""
         self.archive_path_processor = HdfsPathProcessor(params=params)
+        self.oozie_node = oozie_node
 
-    def on_parse_node(self):
-        super().on_parse_node()
+    def parse_node(self):
         archive_nodes = self.oozie_node.findall("archive")
         if archive_nodes:
             for archive_node in archive_nodes:
                 archive_path = archive_node.text
                 self.add_archive(archive_path)
+        return self.archives, self.hdfs_archives
 
     def _check_archive_extensions(self, oozie_archive_path: str) -> List[str]:
         """

--- a/oozie-to-airflow/mappers/file_archive_mappers.py
+++ b/oozie-to-airflow/mappers/file_archive_mappers.py
@@ -51,7 +51,7 @@ def split_by_hash_sign(path: str) -> List[str]:
     return [path]
 
 
-class FileMapper:
+class FileExtractor:
     """ Extracts all file paths from an Oozie node """
 
     def __init__(self, oozie_node: Element, params: Dict[str, str]):
@@ -86,7 +86,7 @@ class FileMapper:
         )
 
 
-class ArchiveMapper:
+class ArchiveExtractor:
     """ Extracts all archive paths from an Oozie node """
 
     ALLOWED_EXTENSIONS = [".zip", ".gz", ".tar.gz", ".tar", ".jar"]

--- a/oozie-to-airflow/mappers/file_archive_mappers.py
+++ b/oozie-to-airflow/mappers/file_archive_mappers.py
@@ -52,16 +52,16 @@ def split_by_hash_sign(path: str) -> List[str]:
 
 
 class FileMapper:
-    """ Converts a file oozie node """
+    """ Extracts all file paths from an Oozie node """
 
     def __init__(self, oozie_node: Element, params: Dict[str, str]):
-        self.files = ""
-        self.hdfs_files = ""
+        self.files: str = ""
+        self.hdfs_files: str = ""
         self.file_path_processor = HdfsPathProcessor(params=params)
         self.oozie_node = oozie_node
 
     def parse_node(self):
-        file_nodes = self.oozie_node.findall("file")
+        file_nodes: List[Element] = self.oozie_node.findall("file")
 
         for file_node in file_nodes:
             file_path = file_node.text
@@ -87,18 +87,18 @@ class FileMapper:
 
 
 class ArchiveMapper:
-    """ Converts an archive oozie node """
+    """ Extracts all archive paths from an Oozie node """
 
     ALLOWED_EXTENSIONS = [".zip", ".gz", ".tar.gz", ".tar", ".jar"]
 
     def __init__(self, oozie_node: Element, params: Dict[str, str]):
-        self.archives = ""
-        self.hdfs_archives = ""
+        self.archives: str = ""
+        self.hdfs_archives: str = ""
         self.archive_path_processor = HdfsPathProcessor(params=params)
         self.oozie_node = oozie_node
 
     def parse_node(self):
-        archive_nodes = self.oozie_node.findall("archive")
+        archive_nodes: List[Element] = self.oozie_node.findall("archive")
         if archive_nodes:
             for archive_node in archive_nodes:
                 archive_path = archive_node.text

--- a/oozie-to-airflow/mappers/file_archive_mixins.py
+++ b/oozie-to-airflow/mappers/file_archive_mixins.py
@@ -61,11 +61,11 @@ class FileMixin:
 
     def on_parse_node(self):
         super().on_parse_node()
-        archive_nodes = self.oozie_node.findall("archive")
+        file_nodes = self.oozie_node.findall("file")
 
-        for archive_node in archive_nodes:
-            archive_path = archive_node.text
-            self.add_archive(archive_path)
+        for file_node in file_nodes:
+            file_path = file_node.text
+            self.add_file(file_path)
 
     def add_file(self, oozie_file_path: str) -> None:
         """

--- a/oozie-to-airflow/mappers/pig_mapper.py
+++ b/oozie-to-airflow/mappers/pig_mapper.py
@@ -27,7 +27,7 @@ from utils import el_utils, xml_utils
 from utils.template_utils import render_template
 
 
-class PigMapper(ActionMapper, PrepareMixin, ArchiveMixin, FileMixin):
+class PigMapper(PrepareMixin, ArchiveMixin, FileMixin, ActionMapper):
     """
     Converts a Pig Oozie node to an Airflow task.
     """

--- a/oozie-to-airflow/mappers/pig_mapper.py
+++ b/oozie-to-airflow/mappers/pig_mapper.py
@@ -21,13 +21,14 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from converter.primitives import Relation
 from mappers.action_mapper import ActionMapper
-from mappers.file_archive_mixins import FileMixin, ArchiveMixin
+from mappers.file_archive_mappers import FileMapper, ArchiveMapper
 from mappers.prepare_mixin import PrepareMixin
 from utils import el_utils, xml_utils
 from utils.template_utils import render_template
 
 
-class PigMapper(PrepareMixin, ArchiveMixin, FileMixin, ActionMapper):
+# pylint: disable=too-many-instance-attributes
+class PigMapper(ActionMapper, PrepareMixin):
     """
     Converts a Pig Oozie node to an Airflow task.
     """
@@ -44,8 +45,6 @@ class PigMapper(PrepareMixin, ArchiveMixin, FileMixin, ActionMapper):
         template_file_name: str = "pig.tpl",
         **kwargs,
     ):
-        ArchiveMixin.__init__(self, params=params)
-        FileMixin.__init__(self, params=params)
         ActionMapper.__init__(self, oozie_node=oozie_node, name=name, trigger_rule=trigger_rule, **kwargs)
         if params is None:
             params = dict()
@@ -54,6 +53,8 @@ class PigMapper(PrepareMixin, ArchiveMixin, FileMixin, ActionMapper):
         self.trigger_rule = trigger_rule
         self.properties = {}
         self.params_dict = {}
+        self.file_mapper = FileMapper(oozie_node=oozie_node, params=params)
+        self.archive_mapper = ArchiveMapper(oozie_node=oozie_node, params=params)
         self._parse_oozie_node()
 
     def _parse_oozie_node(self):
@@ -65,6 +66,8 @@ class PigMapper(PrepareMixin, ArchiveMixin, FileMixin, ActionMapper):
         self.script_file_name = el_utils.replace_el_with_var(script, params=self.params, quote=False)
         self._parse_config()
         self._parse_params()
+        self.files, self.hdfs_files = self.file_mapper.parse_node()
+        self.archives, self.hdfs_archives = self.archive_mapper.parse_node()
 
     def _parse_params(self):
         param_nodes = xml_utils.find_nodes_by_tag(self.oozie_node, "param")

--- a/oozie-to-airflow/mappers/pig_mapper.py
+++ b/oozie-to-airflow/mappers/pig_mapper.py
@@ -21,7 +21,7 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from converter.primitives import Relation
 from mappers.action_mapper import ActionMapper
-from mappers.file_archive_mappers import FileMapper, ArchiveMapper
+from mappers.file_archive_mappers import FileExtractor, ArchiveExtractor
 from mappers.prepare_mixin import PrepareMixin
 from utils import el_utils, xml_utils
 from utils.template_utils import render_template
@@ -53,8 +53,8 @@ class PigMapper(ActionMapper, PrepareMixin):
         self.trigger_rule = trigger_rule
         self.properties = {}
         self.params_dict = {}
-        self.file_mapper = FileMapper(oozie_node=oozie_node, params=params)
-        self.archive_mapper = ArchiveMapper(oozie_node=oozie_node, params=params)
+        self.file_mapper = FileExtractor(oozie_node=oozie_node, params=params)
+        self.archive_mapper = ArchiveExtractor(oozie_node=oozie_node, params=params)
         self._parse_oozie_node()
 
     def _parse_oozie_node(self):

--- a/oozie-to-airflow/tests/converter/test_oozie_parser.py
+++ b/oozie-to-airflow/tests/converter/test_oozie_parser.py
@@ -410,7 +410,7 @@ class TestOozieExamples(unittest.TestCase):
                         Relation(from_task_id="decision_node", to_task_id="fail"),
                         Relation(from_task_id="decision_node", to_task_id="fake_end"),
                     },
-                    params={},
+                    params={"nameNode": "hdfs://"},
                 ),
             ),
             (
@@ -436,20 +436,41 @@ class TestOozieExamples(unittest.TestCase):
                         Relation(from_task_id="pig_node", to_task_id="join_node"),
                         Relation(from_task_id="streaming_node", to_task_id="join_node"),
                     },
-                    params={},
+                    params={"nameNode": "hdfs://"},
                 ),
             ),
             (
                 WorkflowTestCase(
-                    name="el", node_names={"ssh"}, relations=set(), params={"hostname": "AAAA@BBB"}
+                    name="el",
+                    node_names={"ssh"},
+                    relations=set(),
+                    params={"hostname": "AAAA@BBB", "nameNode": "hdfs://"},
                 ),
             ),
-            (WorkflowTestCase(name="pig", node_names={"pig_node"}, relations=set(), params={}),),
-            (WorkflowTestCase(name="shell", node_names={"shell_node"}, relations=set(), params={}),),
-            (WorkflowTestCase(name="spark", node_names={"spark_node"}, relations=set(), params={}),),
             (
                 WorkflowTestCase(
-                    name="ssh", node_names={"ssh"}, relations=set(), params={"hostname": "AAAA@BBB"}
+                    name="pig",
+                    node_names={"pig_node"},
+                    relations=set(),
+                    params={"oozie.wf.application.path": "hdfs://", "nameNode": "hdfs://"},
+                ),
+            ),
+            (
+                WorkflowTestCase(
+                    name="shell", node_names={"shell_node"}, relations=set(), params={"nameNode": "hdfs://"}
+                ),
+            ),
+            (
+                WorkflowTestCase(
+                    name="spark", node_names={"spark_node"}, relations=set(), params={"nameNode": "hdfs://"}
+                ),
+            ),
+            (
+                WorkflowTestCase(
+                    name="ssh",
+                    node_names={"ssh"},
+                    relations=set(),
+                    params={"hostname": "AAAA@BBB", "nameNode": "hdfs://"},
                 ),
             ),
         ],
@@ -466,9 +487,6 @@ class TestOozieExamples(unittest.TestCase):
             control_mapper=CONTROL_MAP,
         )
         current_parser.parse_workflow()
-
         self.assertEqual(case.node_names, set(current_parser.workflow.nodes.keys()))
-
         self.assertEqual(case.relations, current_parser.workflow.relations)
-
         on_parse_finish_mock.assert_called()

--- a/oozie-to-airflow/tests/mappers/test_archive_mixin.py
+++ b/oozie-to-airflow/tests/mappers/test_archive_mixin.py
@@ -12,10 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests Archive Mixin"""
+"""Tests Archive mapper"""
 import unittest
+from xml.etree.ElementTree import Element
 
-from mappers.file_archive_mixins import ArchiveMixin
+from mappers.file_archive_mappers import ArchiveMapper
 
 
 class TestArchiveMixin(unittest.TestCase):
@@ -27,35 +28,35 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_relative_archive(self):
         # Given
-        archive_mixin = ArchiveMixin(params=self.default_params)
+        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        archive_mixin.add_archive("test_archive.zip")
+        archive_mapper.add_archive("test_archive.zip")
         # Then
-        self.assertEqual(archive_mixin.archives, "test_archive.zip")
+        self.assertEqual(archive_mapper.archives, "test_archive.zip")
         self.assertEqual(
-            archive_mixin.hdfs_archives, "hdfs:///user/pig/examples/pig_test_node/test_archive.zip"
+            archive_mapper.hdfs_archives, "hdfs:///user/pig/examples/pig_test_node/test_archive.zip"
         )
 
     def test_add_absolute_archive(self):
         # Given
-        archive_mixin = ArchiveMixin(params=self.default_params)
+        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        archive_mixin.add_archive("/test_archive.zip")
+        archive_mapper.add_archive("/test_archive.zip")
         # Then
-        self.assertEqual(archive_mixin.archives, "/test_archive.zip")
-        self.assertEqual(archive_mixin.hdfs_archives, "hdfs:///test_archive.zip")
+        self.assertEqual(archive_mapper.archives, "/test_archive.zip")
+        self.assertEqual(archive_mapper.hdfs_archives, "hdfs:///test_archive.zip")
 
     def test_add_multiple_archives(self):
         # Given
-        archive_mixin = ArchiveMixin(params=self.default_params)
+        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        archive_mixin.add_archive("/test_archive.zip")
-        archive_mixin.add_archive("test_archive2.tar")
-        archive_mixin.add_archive("/test_archive3.tar.gz")
+        archive_mapper.add_archive("/test_archive.zip")
+        archive_mapper.add_archive("test_archive2.tar")
+        archive_mapper.add_archive("/test_archive3.tar.gz")
         # Then
-        self.assertEqual(archive_mixin.archives, "/test_archive.zip,test_archive2.tar,/test_archive3.tar.gz")
+        self.assertEqual(archive_mapper.archives, "/test_archive.zip,test_archive2.tar,/test_archive3.tar.gz")
         self.assertEqual(
-            archive_mixin.hdfs_archives,
+            archive_mapper.hdfs_archives,
             "hdfs:///test_archive.zip,"
             "hdfs:///user/pig/examples/pig_test_node/test_archive2.tar,"
             "hdfs:///test_archive3.tar.gz",
@@ -63,18 +64,18 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_hash_archives(self):
         # Given
-        archive_mixin = ArchiveMixin(params=self.default_params)
+        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        archive_mixin.add_archive("/test_archive.zip#test3_link")
-        archive_mixin.add_archive("test_archive2.tar#test_link")
-        archive_mixin.add_archive("/test_archive3.tar.gz")
+        archive_mapper.add_archive("/test_archive.zip#test3_link")
+        archive_mapper.add_archive("test_archive2.tar#test_link")
+        archive_mapper.add_archive("/test_archive3.tar.gz")
         # Then
         self.assertEqual(
-            archive_mixin.archives,
+            archive_mapper.archives,
             "/test_archive.zip#test3_link,test_archive2.tar#test_link,/test_archive3.tar.gz",
         )
         self.assertEqual(
-            archive_mixin.hdfs_archives,
+            archive_mapper.hdfs_archives,
             "hdfs:///test_archive.zip#test3_link,"
             "hdfs:///user/pig/examples/pig_test_node/test_archive2.tar#test_link,"
             "hdfs:///test_archive3.tar.gz",
@@ -82,10 +83,10 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_archive_extra_hash(self):
         # Given
-        archive_mixin = ArchiveMixin(params=self.default_params)
+        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
         with self.assertRaises(Exception) as context:
-            archive_mixin.add_archive("/test_archive.zip#4rarear#")
+            archive_mapper.add_archive("/test_archive.zip#4rarear#")
         # Then
         self.assertEqual(
             "There should be maximum one '#' in the path /test_archive.zip#4rarear#", str(context.exception)

--- a/oozie-to-airflow/tests/mappers/test_archive_mixin.py
+++ b/oozie-to-airflow/tests/mappers/test_archive_mixin.py
@@ -16,7 +16,7 @@
 import unittest
 from xml.etree.ElementTree import Element
 
-from mappers.file_archive_mappers import ArchiveMapper
+from mappers.file_archive_mappers import ArchiveExtractor
 
 
 class TestArchiveMixin(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_relative_archive(self):
         # Given
-        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
+        archive_mapper = ArchiveExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         archive_mapper.add_archive("test_archive.zip")
         # Then
@@ -39,7 +39,7 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_absolute_archive(self):
         # Given
-        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
+        archive_mapper = ArchiveExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         archive_mapper.add_archive("/test_archive.zip")
         # Then
@@ -48,7 +48,7 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_multiple_archives(self):
         # Given
-        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
+        archive_mapper = ArchiveExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         archive_mapper.add_archive("/test_archive.zip")
         archive_mapper.add_archive("test_archive2.tar")
@@ -64,7 +64,7 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_hash_archives(self):
         # Given
-        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
+        archive_mapper = ArchiveExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         archive_mapper.add_archive("/test_archive.zip#test3_link")
         archive_mapper.add_archive("test_archive2.tar#test_link")
@@ -83,7 +83,7 @@ class TestArchiveMixin(unittest.TestCase):
 
     def test_add_archive_extra_hash(self):
         # Given
-        archive_mapper = ArchiveMapper(oozie_node=Element("fake"), params=self.default_params)
+        archive_mapper = ArchiveExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         with self.assertRaises(Exception) as context:
             archive_mapper.add_archive("/test_archive.zip#4rarear#")

--- a/oozie-to-airflow/tests/mappers/test_file_mixin.py
+++ b/oozie-to-airflow/tests/mappers/test_file_mixin.py
@@ -12,10 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests File mixin"""
+"""Tests File mapper"""
 import unittest
+from xml.etree.ElementTree import Element
 
-from mappers.file_archive_mixins import FileMixin
+from mappers.file_archive_mappers import FileMapper
 
 
 class TestFileMixin(unittest.TestCase):
@@ -27,47 +28,47 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_relative_file(self):
         # Given
-        file_mixin = FileMixin(params=self.default_params)
+        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        file_mixin.add_file("test_file")
+        file_mapper.add_file("test_file")
         # Then
-        self.assertEqual(file_mixin.files, "test_file")
-        self.assertEqual(file_mixin.hdfs_files, "hdfs:///user/pig/examples/pig_test_node/test_file")
+        self.assertEqual(file_mapper.files, "test_file")
+        self.assertEqual(file_mapper.hdfs_files, "hdfs:///user/pig/examples/pig_test_node/test_file")
 
     def test_add_absolute_file(self):
         # Given
-        file_mixin = FileMixin(params=self.default_params)
+        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        file_mixin.add_file("/test_file")
+        file_mapper.add_file("/test_file")
         # Then
-        self.assertEqual(file_mixin.files, "/test_file")
-        self.assertEqual(file_mixin.hdfs_files, "hdfs:///test_file")
+        self.assertEqual(file_mapper.files, "/test_file")
+        self.assertEqual(file_mapper.hdfs_files, "hdfs:///test_file")
 
     def test_add_multiple_files(self):
         # Given
-        file_mixin = FileMixin(params=self.default_params)
+        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        file_mixin.add_file("/test_file")
-        file_mixin.add_file("test_file2")
-        file_mixin.add_file("/test_file3")
+        file_mapper.add_file("/test_file")
+        file_mapper.add_file("test_file2")
+        file_mapper.add_file("/test_file3")
         # Then
-        self.assertEqual(file_mixin.files, "/test_file,test_file2,/test_file3")
+        self.assertEqual(file_mapper.files, "/test_file,test_file2,/test_file3")
         self.assertEqual(
-            file_mixin.hdfs_files,
+            file_mapper.hdfs_files,
             "hdfs:///test_file," "hdfs:///user/pig/examples/pig_test_node/test_file2," "hdfs:///test_file3",
         )
 
     def test_add_hash_files(self):
         # Given
-        file_mixin = FileMixin(params=self.default_params)
+        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
-        file_mixin.add_file("/test_file#test3_link")
-        file_mixin.add_file("test_file2#test_link")
-        file_mixin.add_file("/test_file3")
+        file_mapper.add_file("/test_file#test3_link")
+        file_mapper.add_file("test_file2#test_link")
+        file_mapper.add_file("/test_file3")
         # Then
-        self.assertEqual(file_mixin.files, "/test_file#test3_link,test_file2#test_link,/test_file3")
+        self.assertEqual(file_mapper.files, "/test_file#test3_link,test_file2#test_link,/test_file3")
         self.assertEqual(
-            file_mixin.hdfs_files,
+            file_mapper.hdfs_files,
             "hdfs:///test_file#test3_link,"
             "hdfs:///user/pig/examples/pig_test_node/test_file2#test_link,"
             "hdfs:///test_file3",
@@ -75,10 +76,10 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_file_extra_hash(self):
         # Given
-        file_mixin = FileMixin(params=self.default_params)
+        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
         # When
         with self.assertRaises(Exception) as context:
-            file_mixin.add_file("/test_file#4rarear#")
+            file_mapper.add_file("/test_file#4rarear#")
         # Then
         self.assertEqual(
             "There should be maximum one '#' in the path /test_file#4rarear#", str(context.exception)

--- a/oozie-to-airflow/tests/mappers/test_file_mixin.py
+++ b/oozie-to-airflow/tests/mappers/test_file_mixin.py
@@ -16,7 +16,7 @@
 import unittest
 from xml.etree.ElementTree import Element
 
-from mappers.file_archive_mappers import FileMapper
+from mappers.file_archive_mappers import FileExtractor
 
 
 class TestFileMixin(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_relative_file(self):
         # Given
-        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
+        file_mapper = FileExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         file_mapper.add_file("test_file")
         # Then
@@ -37,7 +37,7 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_absolute_file(self):
         # Given
-        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
+        file_mapper = FileExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         file_mapper.add_file("/test_file")
         # Then
@@ -46,7 +46,7 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_multiple_files(self):
         # Given
-        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
+        file_mapper = FileExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         file_mapper.add_file("/test_file")
         file_mapper.add_file("test_file2")
@@ -60,7 +60,7 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_hash_files(self):
         # Given
-        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
+        file_mapper = FileExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         file_mapper.add_file("/test_file#test3_link")
         file_mapper.add_file("test_file2#test_link")
@@ -76,7 +76,7 @@ class TestFileMixin(unittest.TestCase):
 
     def test_add_file_extra_hash(self):
         # Given
-        file_mapper = FileMapper(oozie_node=Element("fake"), params=self.default_params)
+        file_mapper = FileExtractor(oozie_node=Element("fake"), params=self.default_params)
         # When
         with self.assertRaises(Exception) as context:
             file_mapper.add_file("/test_file#4rarear#")

--- a/oozie-to-airflow/tests/mappers/test_pig_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_pig_mapper.py
@@ -44,10 +44,14 @@ class TestPigMapper(unittest.TestCase):
             <name>mapred.map.output.compress</name>
             <value>false</value>
         </property>
-     </configuration>
-     <script>id.pig</script>
+    </configuration>
+    <script>id.pig</script>
     <param>INPUT=/user/${wf:user()}/${examplesRoot}/input-data/text</param>
     <param>OUTPUT=/user/${wf:user()}/${examplesRoot}/output-data/demo/pig-node</param>
+    <file>test_dir/test.txt#test_link.txt</file>
+    <file>/user/pig/examples/test_pig_node/test_dir/test2.zip#test_link.zip</file>
+    <archive>test_dir/test2.zip#test_zip_dir</archive>
+    <archive>test_dir/test3.zip#test3_zip_dir</archive>
 </pig>
 """
         self.pig_node = ET.fromstring(pig_node_str)

--- a/oozie-to-airflow/tests/mappers/test_pig_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_pig_mapper.py
@@ -48,17 +48,18 @@ class TestPigMapper(unittest.TestCase):
     <script>id.pig</script>
     <param>INPUT=/user/${wf:user()}/${examplesRoot}/input-data/text</param>
     <param>OUTPUT=/user/${wf:user()}/${examplesRoot}/output-data/demo/pig-node</param>
-    <file>test_dir/test.txt#test_link.txt</file>
+    <file>/test_dir/test.txt#test_link.txt</file>
     <file>/user/pig/examples/test_pig_node/test_dir/test2.zip#test_link.zip</file>
-    <archive>test_dir/test2.zip#test_zip_dir</archive>
-    <archive>test_dir/test3.zip#test3_zip_dir</archive>
+    <archive>/test_dir/test2.zip#test_zip_dir</archive>
+    <archive>/test_dir/test3.zip#test3_zip_dir</archive>
 </pig>
 """
         self.pig_node = ET.fromstring(pig_node_str)
 
     def test_create_mapper_no_jinja(self):
+        params = {"nameNode": "hdfs://"}
         mapper = pig_mapper.PigMapper(
-            oozie_node=self.pig_node, name="test_id", trigger_rule=TriggerRule.DUMMY
+            oozie_node=self.pig_node, name="test_id", trigger_rule=TriggerRule.DUMMY, params=params
         )
         # make sure everything is getting initialized correctly
         self.assertEqual("test_id", mapper.name)
@@ -108,7 +109,7 @@ class TestPigMapper(unittest.TestCase):
             oozie_node=self.pig_node,
             name="test_id",
             trigger_rule=TriggerRule.DUMMY,
-            params={"dataproc_cluster": "my-cluster", "gcp_region": "europe-west3"},
+            params={"dataproc_cluster": "my-cluster", "gcp_region": "europe-west3", "nameNode": "hdfs://"},
         )
         # Throws a syntax error if doesn't parse correctly
         ast.parse(mapper.convert_to_text())
@@ -120,7 +121,8 @@ class TestPigMapper(unittest.TestCase):
         ast.parse(imp_str)
 
     def test_first_task_id(self):
+        params = {"nameNode": "hdfs://"}
         mapper = pig_mapper.PigMapper(
-            oozie_node=self.pig_node, name="test_id", trigger_rule=TriggerRule.DUMMY
+            oozie_node=self.pig_node, name="test_id", trigger_rule=TriggerRule.DUMMY, params=params
         )
         self.assertEqual(mapper.first_task_id, "test_id_prepare")


### PR DESCRIPTION
According to the [Oozie schema](https://github.com/apache/oozie/blob/master/client/src/main/resources/oozie-workflow-0.5.xsd) the file and archive
nodes are inside the action operation node, i.e.:
```
<action>
  <pig>
    <file>
    <archive>
```
However the flawed implementation expected them to be one level up:
```
<action>
  <pig>
  </pig>
  <file>
  <archive>
```
This commit fixed that and amends the Pig example
workflow to follow the correct schema.

----

**UPDATE!**

Additionally, there was an error in `FileMixin` where was invoking
`add_archive()` instead of `add_file()`. This is fixed.

Added a unit test for parser validating the parsing of file and
archive nodes (on the basis of Pig).