### PR TITLE
Remove error task, when it's a kill action - fix #76

### DIFF
--- a/oozie-to-airflow/mappers/kill_mapper.py
+++ b/oozie-to-airflow/mappers/kill_mapper.py
@@ -15,6 +15,7 @@
 """Kill mapper - maps the workflow end"""
 from typing import Set
 
+from converter.primitives import Workflow
 from mappers.base_mapper import BaseMapper
 from utils.template_utils import render_template
 
@@ -26,3 +27,11 @@ class KillMapper(BaseMapper):
     @staticmethod
     def required_imports() -> Set[str]:
         return {"from airflow.operators import bash_operator"}
+
+    def on_parse_finish(self, workflow: Workflow):
+        super().on_parse_finish(workflow)
+        if workflow.nodes[self.name].is_error:
+            del workflow.nodes[self.name]
+            workflow.relations -= {
+                relation for relation in workflow.relations if relation.to_task_id == self.name
+            }

--- a/oozie-to-airflow/tests/converter/test_oozie_parser.py
+++ b/oozie-to-airflow/tests/converter/test_oozie_parser.py
@@ -388,7 +388,6 @@ class TestOozieExamples(unittest.TestCase):
                     node_names={
                         "cleanup_node",
                         "decision_node",
-                        "fail",
                         "fork_node",
                         "hdfs_node",
                         "join_node",
@@ -397,18 +396,13 @@ class TestOozieExamples(unittest.TestCase):
                         "streaming_node",
                     },
                     relations={
-                        Relation(from_task_id="cleanup_node", to_task_id="fail"),
                         Relation(from_task_id="cleanup_node", to_task_id="fork_node"),
                         Relation(from_task_id="decision_node", to_task_id="hdfs_node"),
                         Relation(from_task_id="fork_node", to_task_id="pig_node_prepare"),
                         Relation(from_task_id="fork_node", to_task_id="streaming_node"),
-                        Relation(from_task_id="hdfs_node", to_task_id="fail"),
                         Relation(from_task_id="join_node", to_task_id="mr_node"),
                         Relation(from_task_id="mr_node", to_task_id="decision_node"),
-                        Relation(from_task_id="mr_node", to_task_id="fail"),
-                        Relation(from_task_id="pig_node", to_task_id="fail"),
                         Relation(from_task_id="pig_node", to_task_id="join_node"),
-                        Relation(from_task_id="streaming_node", to_task_id="fail"),
                         Relation(from_task_id="streaming_node", to_task_id="join_node"),
                     },
                     params={},
@@ -416,42 +410,15 @@ class TestOozieExamples(unittest.TestCase):
             ),
             (
                 WorkflowTestCase(
-                    name="el",
-                    node_names={"ssh", "fail"},
-                    relations={Relation(from_task_id="ssh", to_task_id="fail")},
-                    params={"hostname": "AAAA@BBB"},
+                    name="el", node_names={"ssh"}, relations=set(), params={"hostname": "AAAA@BBB"}
                 ),
             ),
+            (WorkflowTestCase(name="pig", node_names={"pig_node"}, relations=set(), params={}),),
+            (WorkflowTestCase(name="shell", node_names={"shell_node"}, relations=set(), params={}),),
+            (WorkflowTestCase(name="spark", node_names={"spark_node"}, relations=set(), params={}),),
             (
                 WorkflowTestCase(
-                    name="pig",
-                    node_names={"fail", "pig_node"},
-                    relations={Relation(from_task_id="pig_node", to_task_id="fail")},
-                    params={},
-                ),
-            ),
-            (
-                WorkflowTestCase(
-                    name="shell",
-                    node_names={"shell_node", "fail"},
-                    relations={Relation(from_task_id="shell_node", to_task_id="fail")},
-                    params={},
-                ),
-            ),
-            (
-                WorkflowTestCase(
-                    name="spark",
-                    node_names={"fail", "spark_node"},
-                    relations={Relation(from_task_id="spark_node", to_task_id="fail")},
-                    params={},
-                ),
-            ),
-            (
-                WorkflowTestCase(
-                    name="ssh",
-                    node_names={"ssh", "fail"},
-                    relations={Relation(from_task_id="ssh", to_task_id="fail")},
-                    params={"hostname": "AAAA@BBB"},
+                    name="ssh", node_names={"ssh"}, relations=set(), params={"hostname": "AAAA@BBB"}
                 ),
             ),
         ],


### PR DESCRIPTION
Hello,

I implement a fix for issues: #76 

I note that the base branch is a [workflow-tests](https://github.com/GoogleCloudPlatform/cloud-composer/pull/82).

Before DAG: 
![image](https://user-images.githubusercontent.com/12058428/56119017-80e2d700-5f6b-11e9-9360-71b282805fb8.png)
Source code: https://gist.github.com/mik-laj/0a2b1d02dfe63195b705eac70faf42ad

After DAG:
![image](https://user-images.githubusercontent.com/12058428/56151365-5e73ac80-5fb1-11e9-97b5-4c2357024837.png)

Source code: 
https://gist.github.com/mik-laj/df47f1b76112bd127f8db80d89a61e3f