### PR TITLE
Don't delete end task, when it's used by decision node Fix #90

### DIFF
--- a/oozie-to-airflow/tests/converter/test_oozie_parser.py
+++ b/oozie-to-airflow/tests/converter/test_oozie_parser.py
@@ -405,8 +405,9 @@ class TestOozieExamples(unittest.TestCase):
             (
                 WorkflowTestCase(
                     name="decision",
-                    node_names={"fake_end", "fail", "decision_node"},
+                    node_names={"real_end", "fake_end", "fail", "decision_node"},
                     relations={
+                        Relation(from_task_id="decision_node", to_task_id="real_end"),
                         Relation(from_task_id="decision_node", to_task_id="fail"),
                         Relation(from_task_id="decision_node", to_task_id="fake_end"),
                     },
@@ -425,9 +426,12 @@ class TestOozieExamples(unittest.TestCase):
                         "mr_node",
                         "pig_node",
                         "streaming_node",
+                        "end",
                     },
                     relations={
                         Relation(from_task_id="cleanup_node", to_task_id="fork_node"),
+                        Relation(from_task_id="decision_node", to_task_id="end"),
+                        Relation(from_task_id="hdfs_node", to_task_id="end"),
                         Relation(from_task_id="decision_node", to_task_id="hdfs_node"),
                         Relation(from_task_id="fork_node", to_task_id="pig_node_prepare"),
                         Relation(from_task_id="fork_node", to_task_id="streaming_node"),

--- a/oozie-to-airflow/tests/mappers/test_end_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_end_mapper.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the End mapper."""
+import ast
+import unittest
+from unittest import mock
+from xml.etree.ElementTree import Element
+from airflow.utils.trigger_rule import TriggerRule
+
+from converter.parsed_node import ParsedNode
+from converter.primitives import Workflow, Relation
+from mappers import end_mapper
+from mappers.base_mapper import BaseMapper
+from mappers.decision_mapper import DecisionMapper
+
+
+class TestEndMapper(unittest.TestCase):
+    oozie_node = Element("end")
+
+    def test_create_mapper(self):
+        mapper = end_mapper.EndMapper(
+            oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY
+        )
+        # make sure everything is getting initialized correctly
+        self.assertEqual("test_id", mapper.name)
+        self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
+
+    def test_convert_to_text(self):
+        mapper = end_mapper.EndMapper(
+            oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY
+        )
+        ast.parse(mapper.convert_to_text())
+
+    # pylint: disable=no-self-use
+    def test_required_imports(self):
+        imps = end_mapper.EndMapper.required_imports()
+        imp_str = "\n".join(imps)
+        ast.parse(imp_str)
+
+    def test_on_parse_finish_simple_should_remove_end_node(self):
+        workflow = Workflow(input_directory_path=None, output_directory_path=None, dag_name=None)
+
+        mapper = end_mapper.EndMapper(
+            oozie_node=self.oozie_node, name="second_task", trigger_rule=TriggerRule.DUMMY
+        )
+
+        workflow.nodes["first_task"] = ParsedNode(mock.Mock(autospec=BaseMapper))
+        workflow.nodes["second_task"] = ParsedNode(mapper)
+
+        workflow.relations = {Relation(from_task_id="first_task", to_task_id="second_task")}
+
+        mapper.on_parse_finish(workflow)
+
+        self.assertEqual(set(workflow.nodes.keys()), {"first_task"})
+        self.assertEqual(workflow.relations, set())
+
+    def test_on_parse_finish_decision_should_not_remove_end_node(self):
+        workflow = Workflow(input_directory_path=None, output_directory_path=None, dag_name=None)
+
+        mapper = end_mapper.EndMapper(
+            oozie_node=self.oozie_node, name="second_task", trigger_rule=TriggerRule.DUMMY
+        )
+
+        workflow.nodes["first_task"] = ParsedNode(mock.Mock(spec=DecisionMapper, last_task_id="first_task"))
+        workflow.nodes["second_task"] = ParsedNode(mapper)
+
+        workflow.relations = {Relation(from_task_id="first_task", to_task_id="second_task")}
+
+        mapper.on_parse_finish(workflow)
+
+        self.assertEqual(set(workflow.nodes.keys()), {"first_task", "second_task"})
+        self.assertEqual(workflow.relations, {Relation(from_task_id="first_task", to_task_id="second_task")})

--- a/oozie-to-airflow/tests/mappers/test_start_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_start_mapper.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests Kill Mapper"""
+"""Tests for the Start mapper."""
 import ast
 import unittest
 from unittest import mock
@@ -21,54 +21,40 @@ from airflow.utils.trigger_rule import TriggerRule
 
 from converter.parsed_node import ParsedNode
 from converter.primitives import Workflow, Relation
-from mappers import kill_mapper
 from mappers.base_mapper import BaseMapper
+from mappers.start_mapper import StartMapper
 
 
-class TestKillMapper(unittest.TestCase):
-
-    oozie_node = Element("dummy")
+class TestStartMapper(unittest.TestCase):
+    oozie_node = Element("start")
 
     def test_create_mapper(self):
-        mapper = kill_mapper.KillMapper(
-            oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY
-        )
+        mapper = StartMapper(oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY)
         # make sure everything is getting initialized correctly
         self.assertEqual("test_id", mapper.name)
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
 
     def test_convert_to_text(self):
-        mapper = kill_mapper.KillMapper(
-            oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY
-        )
-        # Throws a syntax error if doesn't parse correctly
+        mapper = StartMapper(oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY)
         ast.parse(mapper.convert_to_text())
 
     # pylint: disable=no-self-use
     def test_required_imports(self):
-        imps = kill_mapper.KillMapper.required_imports()
+        imps = StartMapper.required_imports()
         imp_str = "\n".join(imps)
         ast.parse(imp_str)
 
     def test_on_parse_finish(self):
         workflow = Workflow(input_directory_path=None, output_directory_path=None, dag_name=None)
 
-        mapper = kill_mapper.KillMapper(
-            oozie_node=self.oozie_node, name="fail_task", trigger_rule=TriggerRule.DUMMY
-        )
+        mapper = StartMapper(oozie_node=self.oozie_node, name="first_task", trigger_rule=TriggerRule.DUMMY)
 
-        workflow.nodes["task"] = ParsedNode(mock.Mock(autospec=BaseMapper))
-        workflow.nodes["fail_task"] = ParsedNode(mapper)
-        workflow.nodes["success_task"] = ParsedNode(mock.Mock(autospec=BaseMapper))
-        workflow.nodes["success_task"].set_is_ok(True)
-        workflow.nodes["fail_task"].set_is_error(True)
+        workflow.nodes["first_task"] = ParsedNode(mock.Mock(autospec=BaseMapper))
+        workflow.nodes["second_task"] = ParsedNode(mapper)
 
-        workflow.relations = {
-            Relation(from_task_id="task", to_task_id="fail_task"),
-            Relation(from_task_id="task", to_task_id="success_task"),
-        }
+        workflow.relations = {Relation(from_task_id="first_task", to_task_id="second_task")}
 
         mapper.on_parse_finish(workflow)
 
-        self.assertEqual(set(workflow.nodes.keys()), {"task", "success_task"})
-        self.assertEqual(workflow.relations, {Relation(from_task_id="task", to_task_id="success_task")})
+        self.assertEqual(set(workflow.nodes.keys()), {"second_task"})
+        self.assertEqual(workflow.relations, set())


### PR DESCRIPTION
Hello,

I working on a fix for issue - #90. 

In addition, I added the missing tests for start and end mappers.

Source code of DAGs:
https://gist.github.com/mik-laj/d48544c6e68b8dbb34d6a689eba522fa

Visualisation of DAGs:
Before:
![Screenshot 2019-04-19 at 00 57 45](https://user-images.githubusercontent.com/12058428/56396243-38167100-623e-11e9-9bac-ddeaa99ab840.png)
After:
![Screenshot 2019-04-19 at 00 56 53](https://user-images.githubusercontent.com/12058428/56396271-511f2200-623e-11e9-977f-dcfe87908ee7.png)



Greetings