### PR TITLE
Enable Travis on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ env:
 python:
   - "3.6"
 cache: pip
-branches:
-  only:
-    - master
 before_install: cd oozie-to-airflow
 install:
   - pip uninstall -y mock


### PR DESCRIPTION
Hello,

We started using [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). Unfortunately, Travis is not run for these PR, so Travis must be included for each branch to provide CI. 

This is a known problem: https://travis-ci.community/t/draft-pull-requests-not-being-built/2434

Greets,