### PR TITLE
Add detection of missing configuration.properties to o2a.py

### DIFF
--- a/oozie-to-airflow/converter/oozie_converter.py
+++ b/oozie-to-airflow/converter/oozie_converter.py
@@ -32,6 +32,7 @@ from converter.primitives import Relation
 from mappers.action_mapper import ActionMapper
 from mappers.base_mapper import BaseMapper
 from utils import el_utils
+from utils.constants import CONFIGURATION_PROPERTIES, JOB_PROPERTIES
 from utils.el_utils import comma_separated_string_to_list
 from utils.template_utils import render_template
 
@@ -70,8 +71,8 @@ class OozieConverter:
         self.start_days_ago = start_days_ago
         self.schedule_interval = schedule_interval
         self.dag_name = dag_name
-        self.configuration_properties_file = os.path.join(input_directory_path, "configuration.properties")
-        self.job_properties_file = os.path.join(input_directory_path, "job.properties")
+        self.configuration_properties_file = os.path.join(input_directory_path, CONFIGURATION_PROPERTIES)
+        self.job_properties_file = os.path.join(input_directory_path, JOB_PROPERTIES)
         self.output_dag_name = (
             os.path.join(output_directory_path, output_dag_name)
             if output_dag_name

--- a/oozie-to-airflow/o2a.py
+++ b/oozie-to-airflow/o2a.py
@@ -16,9 +16,11 @@
 import argparse
 import os
 import sys
+import logging
 
 from converter.oozie_converter import OozieConverter
 from converter.mappers import ACTION_MAP, CONTROL_MAP
+from utils.constants import CONFIGURATION_PROPERTIES
 
 INDENT = 4
 
@@ -35,6 +37,23 @@ def main():
 
     if not dag_name:
         dag_name = os.path.basename(input_directory_path)
+
+    conf_path = os.path.join(input_directory_path, CONFIGURATION_PROPERTIES)
+    if not os.path.isfile(conf_path):
+        logging.warning(
+            f"""
+
+#################################### WARNING ###########################################
+
+The '{CONFIGURATION_PROPERTIES}' file was not detected in {input_directory_path}.
+It may be necessary to provide input parameters for the workflow.
+
+In case of any conversion errors make sure this configuration file is really not needed.
+Otherwise please provide it.
+
+########################################################################################
+        """
+        )
 
     os.makedirs(output_directory_path, exist_ok=True)
 

--- a/oozie-to-airflow/utils/constants.py
+++ b/oozie-to-airflow/utils/constants.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" List of project-wide constants """
+
+CONFIGURATION_PROPERTIES = "configuration.properties"
+JOB_PROPERTIES = "job.properties"

--- a/oozie-to-airflow/utils/el_utils.py
+++ b/oozie-to-airflow/utils/el_utils.py
@@ -160,7 +160,7 @@ def parse_els(properties_file: Optional[str], prop_dict: Dict[str, str] = None):
                     else:
                         _convert_line(line, prop_dict)
         else:
-            logging.warning(f"The job.properties file is missing: {properties_file}")
+            logging.warning(f"The properties file is missing: {properties_file}")
     return prop_dict
 
 


### PR DESCRIPTION
Added a verbose warning about missing `configuration.properties` to `o2a.py`.

Such a detection is already in the `run-sys-test` script, however it does not handle the situation when a user converts the workflow directly running `o2a.py`.

Before, if the `configuration.properties` was missing and needed, the user would get a stack trace with an enigmatic error.

This PR adds a verbose warning which suggests that if there are any conversion errors, the missing `configuration.properties` file might be the culprit.