### PR TITLE
Sorting imports alphabetically

### DIFF
--- a/oozie-to-airflow/converter/oozie_converter.py
+++ b/oozie-to-airflow/converter/oozie_converter.py
@@ -183,7 +183,7 @@ class OozieConverter:
         Of the form: from time import time, etc.
         """
         logging.info("Writing imports to file")
-        file.write(f"\n{line_prefix}".join(depends))
+        file.write(f"\n{line_prefix}".join(sorted(depends)))
         file.write("\n\n")
 
     @staticmethod

--- a/oozie-to-airflow/tests/converter/test_oozie_converter.py
+++ b/oozie-to-airflow/tests/converter/test_oozie_converter.py
@@ -89,7 +89,7 @@ class TestOozieConverter(unittest.TestCase):
         OozieConverter.write_dependencies(file, depends)
         file.seek(0)
 
-        expected = "\n".join(depends) + "\n\n"
+        expected = "from jaws import thriller\nimport airflow\n\n"
         self.assertEqual(expected, file.read())
 
     def test_write_dag_header(self):


### PR DESCRIPTION
Hello,

The position of imports is non-deterministic. This makes it difficult to compare changes in generated Python files.

This change introduces alphabetical sorting. In the future, it is worth developing to sort according to PEP8.

Thanks