### PR TITLE
Prohibit undefined values in templates

### DIFF
--- a/oozie-to-airflow/tests/test_templates.py
+++ b/oozie-to-airflow/tests/test_templates.py
@@ -198,7 +198,7 @@ class MapReduceTemplateTestCase(unittest.TestCase, TemplateTestMixin):
         res = render_template(self.TEMPLATE_NAME, **self.DEFAULT_TEMPLATE_PARAMS)
         self.assertValidPython(res)
 
-    @parameterized.expand([({"hdfs_files": DELETE_MARKER},), ({"hdfs_archives": DELETE_MARKER},)])
+    @parameterized.expand([({"hdfs_files": None},), ({"hdfs_archives": None},)])
     def test_optional_parameters(self, mutation):
         template_params = mutate(self.DEFAULT_TEMPLATE_PARAMS, mutation)
         res = render_template("mapreduce.tpl", **template_params)
@@ -223,9 +223,7 @@ class PigTemplateTestCase(unittest.TestCase, TemplateTestMixin):
         res = render_template(self.TEMPLATE_NAME, **self.DEFAULT_TEMPLATE_PARAMS)
         self.assertValidPython(res)
 
-    @parameterized.expand(
-        [({"params_dict": {"OUTPUT": DELETE_MARKER}},), ({"params_dict": {"INPUT": DELETE_MARKER}},)]
-    )
+    @parameterized.expand([({"params_dict": {"OUTPUT": None}},), ({"params_dict": {"INPUT": None}},)])
     def test_optional_parameters(self, mutation):
         template_params = mutate(self.DEFAULT_TEMPLATE_PARAMS, mutation)
         res = render_template(self.TEMPLATE_NAME, **template_params)
@@ -323,12 +321,12 @@ class SparkTemplateTestCase(unittest.TestCase, TemplateTestMixin):
 
     @parameterized.expand(
         [
-            ({"archives": DELETE_MARKER},),
-            ({"dataproc_spark_jars": DELETE_MARKER},),
-            ({"dataproc_spark_properties": DELETE_MARKER},),
-            ({"files": DELETE_MARKER},),
-            ({"main_class": DELETE_MARKER},),
-            ({"main_jar": DELETE_MARKER},),
+            ({"archives": None},),
+            ({"dataproc_spark_jars": None},),
+            ({"dataproc_spark_properties": None},),
+            ({"files": None},),
+            ({"main_class": None},),
+            ({"main_jar": None},),
         ]
     )
     def test_optional_parameters(self, mutation):
@@ -368,7 +366,7 @@ class SshTemplateTestCase(unittest.TestCase, TemplateTestMixin):
         res = render_template(self.TEMPLATE_NAME, **self.DEFAULT_TEMPLATE_PARAMS)
         self.assertValidPython(res)
 
-    @parameterized.expand([({"params": DELETE_MARKER},)])
+    @parameterized.expand([({"params": None},)])
     def test_optional_parameters(self, mutation):
         template_params = mutate(self.DEFAULT_TEMPLATE_PARAMS, mutation)
         res = render_template(self.TEMPLATE_NAME, **template_params)

--- a/oozie-to-airflow/utils/template_utils.py
+++ b/oozie-to-airflow/utils/template_utils.py
@@ -20,7 +20,7 @@ import jinja2
 from definitions import TPL_PATH
 
 TEMPLATE_LOADER = jinja2.FileSystemLoader(searchpath=TPL_PATH)
-TEMPLATE_ENV = jinja2.Environment(loader=TEMPLATE_LOADER)
+TEMPLATE_ENV = jinja2.Environment(loader=TEMPLATE_LOADER, undefined=jinja2.StrictUndefined)
 TEMPLATE_CACHES: Dict[str, Any] = {}
 
 


### PR DESCRIPTION
Hello,

As a result of a typo, you can use a value that is not passed to the template. This causes difficult to detect errors. I think it's worth blocking the use of undefined values. 

In addition, it will improve the quality of our templates, because any behavior will have to be explicitly expressed.

It is worth remembering that this code does not protect against passing an empty value - `None`.

Thanks,