### PR TITLE
Lint shell scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,9 +83,9 @@ repos:
         always_run: true
     -   id: check-bash-syntax
         name: Check Shell scripts syntax corectness
-        language: system
-        entry: bash -n
-        files: \.sh$
+        language: docker_image
+        entry: koalaman/shellcheck:stable -e SC1091 -e SC2181
+        types: [shell]
     -   id: forbid-unicode-non-breaking-spaces
         name: Detect unicode non-breaking space character U+00A0 aka M-BM-
         language: system

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can run all the checks manually by running:
 `pre-commit run --all-files`
 
 You might need to install xmllint and docker if you do not have it locally. The first can be done with
-`apt install libxml2-utils` on Linux or `brew install xmlstarlet` on MacOS. The second can be made
+`apt install libxml2-utils` on Linux or `brew install xmlstarlet` on MacOS. The second can be done
 according to [the instructions](https://docs.docker.com/install/).
 
 You can always skip running the tests by providing `--no-verify` flag to `git commit` command.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ You can run all the checks manually by running:
 
 `pre-commit run --all-files`
 
-You might need to instal xmllint if you do not have it locally. This can be done
-with `apt install libxml2-utils` on Linux or `brew install xmlstarlet` on MacOS.
+You might need to install xmllint and docker if you do not have it locally. The first can be done with
+`apt install libxml2-utils` on Linux or `brew install xmlstarlet` on MacOS. The second can be made
+according to [the instructions](https://docs.docker.com/install/).
 
 You can always skip running the tests by providing `--no-verify` flag to `git commit` command.
 

--- a/dataproc/example-map-reduce-job.sh
+++ b/dataproc/example-map-reduce-job.sh
@@ -16,7 +16,7 @@
 set -euxo pipefail
 
 # ensure hdfs path exists
-hdfs dfs -mkdir -p /user/$(whoami)/
+hdfs dfs -mkdir -p "/user/$(whoami)/"
 
 # copy examples to home dir
 cp /usr/local/lib/oozie/oozie-examples.tar.gz .

--- a/oozie-to-airflow/confirm
+++ b/oozie-to-airflow/confirm
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+read -r -p "${1}. Are you sure? [y/N] " response
+case "$response" in
+    [yY][eE][sS]|[yY])
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/oozie-to-airflow/init.sh
+++ b/oozie-to-airflow/init.sh
@@ -33,4 +33,4 @@ EOF
 export SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 # Install required dependencies
-pip install -r ${MY_DIR}/../requirements.txt
+pip install -r "${MY_DIR}/../requirements.txt"

--- a/oozie-to-airflow/run-all-conversions
+++ b/oozie-to-airflow/run-all-conversions
@@ -14,13 +14,13 @@
 # limitations under the License.
 set -euo pipefail
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-pushd ${MY_DIR}
+pushd "${MY_DIR}"
 for EXAMPLE in $(cd examples; ls)
 do
-    ./run-sys-test --phase prepare-configuration -a ${EXAMPLE}
+    ./run-sys-test --phase prepare-configuration -a "${EXAMPLE}"
 done
 for EXAMPLE in $(cd examples; ls)
 do
-    ./run-sys-test --phase convert -a ${EXAMPLE}
+    ./run-sys-test --phase convert -a "${EXAMPLE}"
 done
 popd

--- a/oozie-to-airflow/run-all-unit-tests
+++ b/oozie-to-airflow/run-all-unit-tests
@@ -15,6 +15,6 @@
 set -euo pipefail
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-pushd ${MY_DIR}
+pushd "${MY_DIR}"
 pytest tests
 popd

--- a/oozie-to-airflow/run-sys-test
+++ b/oozie-to-airflow/run-sys-test
@@ -19,17 +19,19 @@ set -euo pipefail
 
 # Update short and long options in the complete script
 # This way autocomplete will work automagically with all options
-. ${MY_DIR}/run-sys-test-complete
+# shellcheck source=run-sys-test-complete
+. "${MY_DIR}/run-sys-test-complete"
 
 
 CMDNAME="$(basename -- "$0")"
 
 function save_to_file {
-    echo $(eval echo \$$1) > ${MY_DIR}/.$1
+    # shellcheck disable=SC2005
+    echo "$(eval echo "\$$1")" > "${MY_DIR}/.$1"
 }
 
 function read_from_file {
-    cat ${MY_DIR}/.$1 2>/dev/null || true
+    cat "${MY_DIR}/.$1" 2>/dev/null || true
 }
 
 
@@ -81,13 +83,13 @@ function prepare_configuration {
         echo "Cluster name: ${DATAPROC_CLUSTER_NAME}"
         echo "Region: ${GCP_REGION}"
         echo
-        j2 ${LOCAL_CONFIGURATION_PROPERTIES_TEMPLATE} \
+        j2 "${LOCAL_CONFIGURATION_PROPERTIES_TEMPLATE}" \
               -e DATAPROC_CLUSTER_NAME \
               -e GCP_REGION \
               -e COMPOSER_DAG_BUCKET \
               -e DATAPROC_USER \
               -e LOCAL_APP_NAME \
-              -o ${LOCAL_CONFIGURATION_PROPERTIES}
+              -o "${LOCAL_CONFIGURATION_PROPERTIES}"
     fi
 }
 
@@ -105,7 +107,7 @@ for example application: ${LOCAL_APP_NAME}"
             echo
             exit 1
         fi
-        run_command "mkdir -p ${REMOTE_FILESYSTEM_ALL_APPS_DIR}"
+        run_command "mkdir -p \"${REMOTE_FILESYSTEM_ALL_APPS_DIR}\""
         scp_folder "${LOCAL_APP_DIR}/hdfs/" "${REMOTE_FILESYSTEM_APP_DIR}"
     else
         echo
@@ -117,10 +119,11 @@ for example application: ${LOCAL_APP_NAME}"
     LOCAL_APP_PROPERTIES="/tmp/${LOCAL_APP_NAME}_${RANDOM_PREFIX}_job.properties"
 
     # Overwrite job properties with the dataproc cluster master
-    cat "${LOCAL_APP_DIR}/job.properties" | \
-       sed "s/^nameNode.*$/nameNode=hdfs:\/\/${DATAPROC_CLUSTER_MASTER}:8020/" | \
-       sed "s/^resourceManager.*$/resourceManager=${DATAPROC_CLUSTER_MASTER}:8032/" | \
-       sed "s/\${user\.name}/${DATAPROC_USER}/" > ${LOCAL_APP_PROPERTIES}
+
+    sed -e "s/^nameNode.*$/nameNode=hdfs:\/\/${DATAPROC_CLUSTER_MASTER}:8020/" \
+        -e "s/^resourceManager.*$/resourceManager=${DATAPROC_CLUSTER_MASTER}:8032/" \
+        -e "s/\${user\.name}/${DATAPROC_USER}/" \
+        "${LOCAL_APP_DIR}/job.properties"  > "${LOCAL_APP_PROPERTIES}"
     scp_file "${LOCAL_APP_PROPERTIES}" "${REMOTE_FILESYSTEM_APP_PROPERTIES}"
 
     submit_pig "fs -rm -r -f ${HDFS_REMOTE_APP_DIR}"
@@ -195,14 +198,14 @@ getopt -T >/dev/null
 GETOPT_RETVAL=$?
 
 if [[ $(uname -s) == 'Darwin' ]] ; then
-    which gstat >/dev/null
+    command -v gstat >/dev/null
     STAT_PRESENT=$?
 else
-    which stat >/dev/null
+    command -v stat >/dev/null
     STAT_PRESENT=$?
 fi
 
-which j2 > /dev/null
+command -v j2 > /dev/null
 J2_PRESENT=$?
 
 set -e
@@ -212,13 +215,14 @@ function setup_autocomplete {
     echo "Installing bash completion for local user"
     echo
     set +e
+    # shellcheck disable=SC2088
     grep "~/.bash_completion.d" ~/.bash_profile >/dev/null 2>&1
     RES=$?
     set -e
     if [[ "${RES}" == "0" ]]; then
         echo "Bash dir already created"
     else
-        ${MY_DIR}/confirm "This will create ~/.bash_completion.d/ directory and modify ~/.bash_profile file"
+        "${MY_DIR}/confirm" "This will create ~/.bash_completion.d/ directory and modify ~/.bash_profile file"
         echo
         echo
         mkdir -pv ~/.bash_completion.d
@@ -229,7 +233,7 @@ for BCFILE in ~/.bash_completion.d/* ; do
 done
 EOF
     fi
-    ln -sf ${MY_DIR}/run-sys-test-complete ~/.bash_completion.d/
+    ln -sf "${MY_DIR}/run-sys-test-complete" ~/.bash_completion.d/
     echo
     echo
     echo The run-set-tests completion installed to ~/.bash_completion.d/run-sys-test-complete
@@ -376,6 +380,7 @@ function ssh_to_cluster_master {
     echo "SSH to cluster master ${DATAPROC_CLUSTER_MASTER} in zone ${DATAPROC_MASTER_ZONE}"
     echo
     set -x
+    # shellcheck disable=SC2068
     gcloud compute ssh "${DATAPROC_CLUSTER_MASTER}" --zone "${DATAPROC_MASTER_ZONE}" -- $@
 }
 
@@ -426,27 +431,27 @@ function footer {
 
 
 function run_command {
-    gcloud compute ssh ${DATAPROC_CLUSTER_MASTER} --zone=${DATAPROC_MASTER_ZONE} --command "${1}"
+    gcloud compute ssh "${DATAPROC_CLUSTER_MASTER}" --zone="${DATAPROC_MASTER_ZONE}" --command "${1}"
 }
 
 function scp_folder {
-    gcloud compute scp --zone=${DATAPROC_MASTER_ZONE} --recurse ${1} ${DATAPROC_CLUSTER_MASTER}:${2}
+    gcloud compute scp --zone="${DATAPROC_MASTER_ZONE}" --recurse "${1}" "${DATAPROC_CLUSTER_MASTER}:${2}"
 }
 
 function scp_file {
-    gcloud compute scp --zone=${DATAPROC_MASTER_ZONE} ${1} ${DATAPROC_CLUSTER_MASTER}:${2}
+    gcloud compute scp --zone="${DATAPROC_MASTER_ZONE}" "${1}" "${DATAPROC_CLUSTER_MASTER}:${2}"
 }
 
 function submit_pig {
-    gcloud dataproc jobs submit pig --cluster=${DATAPROC_CLUSTER_NAME} --region=${GCP_REGION} \
+    gcloud dataproc jobs submit pig --cluster="${DATAPROC_CLUSTER_NAME}" --region="${GCP_REGION}" \
         --execute "${1}"
 }
 
 function convert {
     header "Convert workflow.xml to Airflow's ${OUTPUT_DAG_NAME}.py dag for example: ${LOCAL_APP_NAME}"
-    python ${LOCAL_BASE_DIR}/o2a.py -i ${LOCAL_APP_DIR} -o ${LOCAL_OUTPUT_DIR} -u ${DATAPROC_USER} \
-       -d ${OUTPUT_DAG_NAME}
-    python -m py_compile ${LOCAL_OUTPUT_DIR}/${OUTPUT_DAG_NAME}.py
+    python "${LOCAL_BASE_DIR}/o2a.py" -i "${LOCAL_APP_DIR}" -o "${LOCAL_OUTPUT_DIR}" -u "${DATAPROC_USER}" \
+       -d "${OUTPUT_DAG_NAME}"
+    python -m py_compile "${LOCAL_OUTPUT_DIR}/${OUTPUT_DAG_NAME}.py"
     footer
 }
 
@@ -456,7 +461,7 @@ function test_composer {
 
     gcloud composer environments run "${COMPOSER_NAME}" --location "${COMPOSER_LOCATION}" list_dags
     gcloud composer environments run "${COMPOSER_NAME}" --location "${COMPOSER_LOCATION}" trigger_dag\
-       -- ${OUTPUT_DAG_NAME}
+       -- "${OUTPUT_DAG_NAME}"
     echo
     echo "You can check the progress at the address: ${COMPOSER_WEB_UI_URL}"
     echo
@@ -497,8 +502,8 @@ function fetch_composer_environment_info {
 function fetch_dataproc_environment_info {
     header "Fetching information about the Dataproc environment"
     echo
-    DATAPROC_CLUSTER_MASTER=$(gcloud dataproc clusters describe ${DATAPROC_CLUSTER_NAME} --region=${GCP_REGION} --format='value(config.masterConfig.instanceNames[0])')
-    DATAPROC_MASTER_ZONE=$(gcloud dataproc clusters describe ${DATAPROC_CLUSTER_NAME} --region=${GCP_REGION} --format='value(config.gceClusterConfig.zoneUri.basename())')
+    DATAPROC_CLUSTER_MASTER=$(gcloud dataproc clusters describe "${DATAPROC_CLUSTER_NAME}" --region="${GCP_REGION}" --format='value(config.masterConfig.instanceNames[0])')
+    DATAPROC_MASTER_ZONE=$(gcloud dataproc clusters describe "${DATAPROC_CLUSTER_NAME}" --region="${GCP_REGION}" --format='value(config.gceClusterConfig.zoneUri.basename())')
     DATAPROC_USER=$(run_command "whoami")
     REMOTE_FILESYSTEM_ALL_APPS_DIR=/home/${DATAPROC_USER}/o2a
     REMOTE_FILESYSTEM_APP_DIR=${REMOTE_FILESYSTEM_ALL_APPS_DIR}/${LOCAL_APP_NAME}
@@ -513,6 +518,7 @@ fi
 
 if [[ ${RUN_SSH_COMMAND} == "true" ]]; then
     fetch_dataproc_environment_info
+    # shellcheck disable=SC2068
     ssh_to_cluster_master $@
     exit
 fi

--- a/oozie-to-airflow/run-sys-test-complete
+++ b/oozie-to-airflow/run-sys-test-complete
@@ -13,14 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-_MY_LINKED_DIR="$( cd "$( dirname "$(readlink ${BASH_SOURCE[0]})" )" && pwd )"
+_MY_LINKED_DIR="$( cd "$( dirname "$(readlink "${BASH_SOURCE[0]}" )" )" && pwd )"
 
 _SHORT_OPTIONS="
 h a: p: C: L: b: c: m: r: z: v A S
 "
 
 _ALLOWED_PHASES=" prepare-configuration convert prepare-dataproc test-composer test-oozie "
-_ALLOWED_APPLICATIONS=" $(ls ${_MY_LINKED_DIR}/examples | xargs) "
+# shellcheck disable=SC2011
+_ALLOWED_APPLICATIONS=" $(ls "${_MY_LINKED_DIR}/examples" | xargs) "
 
 _LONG_OPTIONS="
 help application: composer-name: composer-location: phase: bucket: cluster:
@@ -66,7 +67,7 @@ function _build_options {
 function _listcontains {
   local WORD
   for WORD in $1; do
-    [[ ${WORD} = $2 ]] && return 0
+    [[ "${WORD}" = "$2" ]] && return 0
   done
   return 1
 }
@@ -100,6 +101,7 @@ function _comp_run_sys_test {
     done
 
     LAST_COMMAND_PREFIX="${COMP_WORDS[${#COMP_WORDS[@]}-1]}"
+    # shellcheck disable=SC2071
     if [[ ${#COMP_WORDS[@]} > 1 ]]; then
         PREVIOUS_COMMAND="${COMP_WORDS[${#COMP_WORDS[@]}-2]}"
     else
@@ -109,8 +111,10 @@ function _comp_run_sys_test {
     if _listcontains "${EXTRA_ARG_OPTIONS}" "${PREVIOUS_COMMAND}"; then
         COMPREPLY=()
         _get_known_values "${PREVIOUS_COMMAND}"
+        # shellcheck disable=SC2207
         COMPREPLY+=($(compgen -W "${_KNOWN_VALUES}" -- "${LAST_COMMAND_PREFIX}"))
     else
+        # shellcheck disable=SC2207
         COMPREPLY+=($(compgen -W "${ALL_OPTIONS}" -- "${LAST_COMMAND_PREFIX}"))
     fi
 }

--- a/oozie-to-airflow/scripts/prepare.sh
+++ b/oozie-to-airflow/scripts/prepare.sh
@@ -35,13 +35,14 @@ done
 
 for DEL_DIR in ${DEL_DIRS}; do
     set +e
-    gcloud dataproc jobs submit pig --cluster=${CLUSTER} --region=${REGION} --execute 'fs -test -d '${DEL_DIR}
+    gcloud dataproc jobs submit pig --cluster="${CLUSTER}" --region="${REGION}" --execute "fs -test -d \"${DEL_DIR}\'"
+    # shellcheck disable=SC2181
     if [[ $? == "0" ]]; then
-        gcloud dataproc jobs submit pig --cluster=${CLUSTER} --region=${REGION} --execute 'fs -rm -r '${DEL_DIR}
+        gcloud dataproc jobs submit pig --cluster="${CLUSTER}" --region="${REGION}" --execute "fs -rm -r \"${DEL_DIR}\""
     fi
     set -e
 done
 
 for MK_DIR in ${MK_DIRS}; do
-    gcloud dataproc jobs submit pig --cluster=${CLUSTER} --region=${REGION} --execute 'fs -mkdir -p '${MK_DIR}
+    gcloud dataproc jobs submit pig --cluster="${CLUSTER}" --region="${REGION}" --execute "fs -mkdir -p \"${MK_DIR}\""
 done

--- a/oozie-to-airflow/validate-all-workflows
+++ b/oozie-to-airflow/validate-all-workflows
@@ -14,6 +14,5 @@
 # limitations under the License.
 set -euo pipefail
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ALL_WORKFLOWS=$(find ${MY_DIR} -name 'workflow.xml')
 
-${MY_DIR}/validate-workflows ${ALL_WORKFLOWS}
+find "${MY_DIR}" -name 'workflow.xml' | xargs -0 "${MY_DIR}/validate-workflows"

--- a/oozie-to-airflow/validate-workflows
+++ b/oozie-to-airflow/validate-workflows
@@ -14,7 +14,9 @@
 # limitations under the License.
 set -euo pipefail
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-WORKFLOWS=${@}
+
+# shellcheck disable=SC2206
+WORKFLOWS=( $@ )
 
 FAILED_WORKFLOWS=""
 VERBOSE=${VERBOSE:=""}
@@ -24,14 +26,13 @@ if [[ "${VERBOSE}" != "" ]]; then
     XMLLINT_EXTRA_PARAMS="--load-trace"
 fi
 
-for WORKFLOW in ${WORKFLOWS}
-do
+for WORKFLOW in "${WORKFLOWS[@]}"; do
     echo
     echo "Validating ${WORKFLOW}"
     echo
     set +e
     # Note - if you add new actions add the schema for this action to "all-schemas-1.0.xsd"
-    xmllint --noout ${XMLLINT_EXTRA_PARAMS} --schema ${MY_DIR}/schema/all-schemas-1.0.xsd ${WORKFLOW}
+    xmllint --noout ${XMLLINT_EXTRA_PARAMS} --schema "${MY_DIR}/schema/all-schemas-1.0.xsd" "${WORKFLOW}"
     ERR=$?
     set -e
     if [[ ${ERR} != "0" ]]; then


### PR DESCRIPTION
Hello,

The current linter had serious limitations. I could not get him to report a problem. 

Additionally, the linter configuration checked only files with the extension ".sh", but we have most of the files without this extension. I turned on checking for all scripts.

I did it immediately when I noticed it because it is a small change, but it will improve our software development process. It also fixes a lot of small errors, which can be a source of big problems and a lot of wasted time.

Thanks