### PR TITLE
Remove template constructor parameter

### DIFF
--- a/oozie-to-airflow/mappers/mapreduce_mapper.py
+++ b/oozie-to-airflow/mappers/mapreduce_mapper.py
@@ -41,13 +41,11 @@ class MapReduceMapper(ActionMapper, PrepareMixin):
         name: str,
         trigger_rule: str = TriggerRule.ALL_SUCCESS,
         params=None,
-        template_file_name: str = "mapreduce.tpl",
         **kwargs,
     ):
         ActionMapper.__init__(self, oozie_node=oozie_node, name=name, trigger_rule=trigger_rule, **kwargs)
         if params is None:
             params = dict()
-        self.template = template_file_name
         self.params = params
         self.trigger_rule = trigger_rule
         self.properties = {}

--- a/oozie-to-airflow/mappers/pig_mapper.py
+++ b/oozie-to-airflow/mappers/pig_mapper.py
@@ -42,13 +42,11 @@ class PigMapper(ActionMapper, PrepareMixin):
         name: str,
         trigger_rule: str = TriggerRule.ALL_SUCCESS,
         params=None,
-        template_file_name: str = "pig.tpl",
         **kwargs,
     ):
         ActionMapper.__init__(self, oozie_node=oozie_node, name=name, trigger_rule=trigger_rule, **kwargs)
         if params is None:
             params = dict()
-        self.template = template_file_name
         self.params = params
         self.trigger_rule = trigger_rule
         self.properties = {}

--- a/oozie-to-airflow/mappers/shell_mapper.py
+++ b/oozie-to-airflow/mappers/shell_mapper.py
@@ -39,13 +39,11 @@ class ShellMapper(ActionMapper, PrepareMixin):
         name: str,
         trigger_rule: str = TriggerRule.ALL_SUCCESS,
         params: Dict[str, str] = None,
-        template: str = "shell.tpl",
         **kwargs,
     ):
         ActionMapper.__init__(self, oozie_node, name, trigger_rule, **kwargs)
         if params is None:
             params = {}
-        self.template = template
         self.params = params
         self.trigger_rule = trigger_rule
         self._parse_oozie_node()

--- a/oozie-to-airflow/mappers/spark_mapper.py
+++ b/oozie-to-airflow/mappers/spark_mapper.py
@@ -55,11 +55,9 @@ class SparkMapper(ActionMapper, PrepareMixin):
         name: str,
         trigger_rule: str = TriggerRule.ALL_SUCCESS,
         params: Dict[str, str] = None,
-        template: str = "spark.tpl",
         **kwargs,
     ):
         ActionMapper.__init__(self, oozie_node, name, trigger_rule, **kwargs)
-        self.template = template
         self.params = params or {}
         self.trigger_rule = trigger_rule
         self.java_class = ""

--- a/oozie-to-airflow/mappers/subworkflow_mapper.py
+++ b/oozie-to-airflow/mappers/subworkflow_mapper.py
@@ -49,13 +49,11 @@ class SubworkflowMapper(ActionMapper):
         control_mapper: Dict[str, Type[BaseMapper]],
         trigger_rule=TriggerRule.ALL_SUCCESS,
         params=None,
-        template="subwf.tpl",
         **kwargs,
     ):
         ActionMapper.__init__(self, oozie_node=oozie_node, name=name, trigger_rule=trigger_rule, **kwargs)
         if params is None:
             params = {}
-        self.template = template
         self.params = params
         self.task_id = name
         self.trigger_rule = trigger_rule
@@ -110,7 +108,7 @@ class SubworkflowMapper(ActionMapper):
         tasks = [
             Task(
                 task_id=self.name,
-                template_name=self.template,
+                template_name="subwf.tpl",
                 template_params=dict(trigger_rule=self.trigger_rule, app_name=self.app_name),
             )
         ]

--- a/oozie-to-airflow/tests/mappers/test_subworkflow_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_subworkflow_mapper.py
@@ -80,7 +80,6 @@ class TestSubworkflowMapper(TestCase):
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
         self.assertEqual(self.subworkflow_node, mapper.oozie_node)
         self.assertEqual(self.main_params, mapper.params)
-        self.assertEqual("subwf.tpl", mapper.template)
         # Propagate config node is present, should forward config properties
         self.assertEqual({"resourceManager": "localhost:8032"}, mapper.get_config_properties())
         self.assertTrue(os.path.isfile(self.SUBDAG_TEST_FILEPATH))
@@ -102,7 +101,6 @@ class TestSubworkflowMapper(TestCase):
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
         self.assertEqual(self.subworkflow_node, mapper.oozie_node)
         self.assertEqual(self.main_params, mapper.params)
-        self.assertEqual("subwf.tpl", mapper.template)
         # Propagate config node is missing, should NOT forward config properties
         self.assertEqual({}, mapper.get_config_properties())
         self.assertTrue(os.path.isfile(self.SUBDAG_TEST_FILEPATH))


### PR DESCRIPTION
Hello,

This template constructor parameter is worth deleting for several reasons:

- It is nowhere to be used.
- One mapper can contain several types of tasks, so the existence of one parameter is not enough.
- In other mappers, this parameter does not exist.
- In other mapper there is, but the implementation does not use it.

Thanks