### PR TITLE
Render all nodes in single place

### DIFF
--- a/oozie-to-airflow/converter/oozie_converter.py
+++ b/oozie-to-airflow/converter/oozie_converter.py
@@ -158,7 +158,13 @@ class OozieConverter:
         :param indent: integer of how many spaces to indent entire operator
         """
         for node in nodes.values():
-            file.write(textwrap.indent(node.mapper.convert_to_text(), indent * " "))
+            tasks, relations = node.mapper.to_tasks_and_relations()
+            file.write(
+                textwrap.indent(
+                    render_template(template_name="action.tpl", tasks=tasks, relations=relations),
+                    indent * " ",
+                )
+            )
             logging.info(f"Wrote tasks corresponding to the action named: {node.mapper.name}")
             node.mapper.copy_extra_assets(
                 input_directory_path=os.path.join(self.input_directory_path, HDFS_FOLDER),

--- a/oozie-to-airflow/converter/parsed_node.py
+++ b/oozie-to-airflow/converter/parsed_node.py
@@ -19,13 +19,15 @@ import logging
 
 from airflow.utils.trigger_rule import TriggerRule
 
-from mappers.base_mapper import BaseMapper
+# Pylint and flake8 does not understand forward references
+# https://www.python.org/dev/peps/pep-0484/#forward-references
+from mappers import base_mapper  # noqa: F401 pylint: disable=unused-import
 
 
 class ParsedNode:
     """Class for parsed Oozie workflow node"""
 
-    def __init__(self, mapper: BaseMapper):
+    def __init__(self, mapper: "base_mapper.BaseMapper"):
         self.mapper = mapper
         self.downstream_names: List[str] = []
         self.is_error: bool = False

--- a/oozie-to-airflow/mappers/base_mapper.py
+++ b/oozie-to-airflow/mappers/base_mapper.py
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Base mapper - it is a base class for all mappers actions, and logic alike"""
-from typing import Set
+from typing import Set, Tuple, List
 from xml.etree.ElementTree import Element
 
 import airflow.utils.trigger_rule
+
+# Pylint and flake8 does not understand forward references
+# https://www.python.org/dev/peps/pep-0484/#forward-references
+from converter import primitives  # noqa: F401 pylint: disable=unused-import
 
 
 class BaseMapper:
@@ -38,10 +42,9 @@ class BaseMapper:
         self.name = name
         self.trigger_rule = trigger_rule
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self) -> Tuple[List["primitives.Task"], List["primitives.Relation"]]:
         """
-        Returns a python operators equivalent string with relation.
-        This will be appended to the file.
+        Convert oozie node to tasks and relations.
         """
         raise NotImplementedError("Not Implemented")
 

--- a/oozie-to-airflow/mappers/decision_mapper.py
+++ b/oozie-to-airflow/mappers/decision_mapper.py
@@ -22,7 +22,6 @@ from airflow.utils.trigger_rule import TriggerRule
 from converter.primitives import Task, Relation
 from mappers.base_mapper import BaseMapper
 from utils.el_utils import convert_el_to_jinja
-from utils.template_utils import render_template
 
 
 # noinspection PyAbstractClass
@@ -84,7 +83,7 @@ class DecisionMapper(BaseMapper):
             else:  # Default return value
                 self.case_dict["default"] = case.attrib["to"]
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self):
         tasks = [
             Task(
                 task_id=self.name,
@@ -94,8 +93,7 @@ class DecisionMapper(BaseMapper):
             )
         ]
         relations: List[Relation] = []
-
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         return {

--- a/oozie-to-airflow/mappers/dummy_mapper.py
+++ b/oozie-to-airflow/mappers/dummy_mapper.py
@@ -18,14 +18,13 @@ from typing import Set
 
 from converter.primitives import Task
 from mappers.action_mapper import ActionMapper
-from utils.template_utils import render_template
 
 
 class DummyMapper(ActionMapper):
-    def convert_to_text(self):
+    def to_tasks_and_relations(self):
         tasks = [Task(task_id=self.name, trigger_rule=self.trigger_rule, template_name="dummy.tpl")]
         relations = []
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         return {"from airflow.operators import dummy_operator"}

--- a/oozie-to-airflow/mappers/fs_mapper.py
+++ b/oozie-to-airflow/mappers/fs_mapper.py
@@ -21,7 +21,6 @@ from xml.etree.ElementTree import Element
 from converter.primitives import Task
 from mappers.action_mapper import ActionMapper
 from utils.relation_utils import chain
-from utils.template_utils import render_template
 from utils.el_utils import normalize_path
 
 ACTION_TYPE = "fs"
@@ -128,8 +127,8 @@ class FsMapper(ActionMapper):
 
         return [self.parse_fs_action(i, node) for i, node in enumerate(self.oozie_node)]
 
-    def convert_to_text(self):
-        return render_template(template_name="action.tpl", tasks=self.tasks, relations=chain(self.tasks))
+    def to_tasks_and_relations(self):
+        return self.tasks, chain(self.tasks)
 
     def required_imports(self) -> Set[str]:
         return {

--- a/oozie-to-airflow/mappers/kill_mapper.py
+++ b/oozie-to-airflow/mappers/kill_mapper.py
@@ -17,7 +17,6 @@ from typing import Set, List
 
 from converter.primitives import Workflow, Task, Relation
 from mappers.base_mapper import BaseMapper
-from utils.template_utils import render_template
 
 
 class KillMapper(BaseMapper):
@@ -25,10 +24,10 @@ class KillMapper(BaseMapper):
     Converts a Kill Oozie node to an Airflow task.
     """
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self):
         tasks = [Task(task_id=self.name, template_name="kill.tpl", trigger_rule=self.trigger_rule)]
         relations: List[Relation] = []
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         return {"from airflow.operators import bash_operator"}

--- a/oozie-to-airflow/mappers/mapreduce_mapper.py
+++ b/oozie-to-airflow/mappers/mapreduce_mapper.py
@@ -23,7 +23,6 @@ from mappers.action_mapper import ActionMapper
 from mappers.prepare_mixin import PrepareMixin
 from utils import el_utils, xml_utils
 from utils.file_archive_extractors import ArchiveExtractor, FileExtractor
-from utils.template_utils import render_template
 
 
 # pylint: disable=too-many-instance-attributes
@@ -71,7 +70,7 @@ class MapReduceMapper(ActionMapper, PrepareMixin):
                 key, value = param.split("=", 1)
                 self.params_dict[key] = value
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self):
         prepare_command = self.get_prepare_command(self.oozie_node, self.params)
         tasks = [
             Task(
@@ -93,7 +92,7 @@ class MapReduceMapper(ActionMapper, PrepareMixin):
             ),
         ]
         relations = [Relation(from_task_id=self.name + "_prepare", to_task_id=self.name)]
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     @staticmethod
     def _validate_paths(input_directory_path, output_directory_path):

--- a/oozie-to-airflow/mappers/null_mapper.py
+++ b/oozie-to-airflow/mappers/null_mapper.py
@@ -25,8 +25,8 @@ class NullMapper(BaseMapper):
         BaseMapper.__init__(self, oozie_node=oozie_node, name=name, trigger_rule=TriggerRule.DUMMY)
 
     # pylint: disable=no-self-use
-    def convert_to_text(self) -> str:
-        return ""
+    def to_tasks_and_relations(self):
+        return [], []
 
     # pylint: disable=no-self-use
     def convert_to_airflow_op(self) -> None:

--- a/oozie-to-airflow/mappers/pig_mapper.py
+++ b/oozie-to-airflow/mappers/pig_mapper.py
@@ -24,7 +24,6 @@ from mappers.action_mapper import ActionMapper
 from mappers.prepare_mixin import PrepareMixin
 from utils import el_utils, xml_utils
 from utils.file_archive_extractors import ArchiveExtractor, FileExtractor
-from utils.template_utils import render_template
 
 
 # pylint: disable=too-many-instance-attributes
@@ -76,7 +75,7 @@ class PigMapper(ActionMapper, PrepareMixin):
                 key, value = param.split("=")
                 self.params_dict[key] = value
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self):
         prepare_command = self.get_prepare_command(self.oozie_node, self.params)
         tasks = [
             Task(
@@ -97,7 +96,7 @@ class PigMapper(ActionMapper, PrepareMixin):
             ),
         ]
         relations = [Relation(from_task_id=self.name + "_prepare", to_task_id=self.name)]
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def _add_symlinks(self, destination_pig_file):
         destination_pig_file.write("set mapred.create.symlink yes;\n")

--- a/oozie-to-airflow/mappers/shell_mapper.py
+++ b/oozie-to-airflow/mappers/shell_mapper.py
@@ -25,8 +25,6 @@ from mappers.action_mapper import ActionMapper
 from mappers.prepare_mixin import PrepareMixin
 from utils import el_utils
 
-from utils.template_utils import render_template
-
 
 class ShellMapper(ActionMapper, PrepareMixin):
     """
@@ -60,7 +58,7 @@ class ShellMapper(ActionMapper, PrepareMixin):
         self.bash_command = el_utils.convert_el_to_jinja(cmd, quote=False)
         self.pig_command = f"sh {shlex.quote(self.bash_command)}"
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self):
         prepare_command = self.get_prepare_command(self.oozie_node, self.params)
         tasks = [
             Task(
@@ -75,7 +73,7 @@ class ShellMapper(ActionMapper, PrepareMixin):
             ),
         ]
         relations = [Relation(from_task_id=self.name + "_prepare", to_task_id=self.name)]
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         return {"from airflow.utils import dates", "from airflow.contrib.operators import dataproc_operator"}

--- a/oozie-to-airflow/mappers/spark_mapper.py
+++ b/oozie-to-airflow/mappers/spark_mapper.py
@@ -24,7 +24,6 @@ from mappers.action_mapper import ActionMapper
 from mappers.prepare_mixin import PrepareMixin
 from utils import xml_utils, el_utils
 from utils.file_archive_extractors import FileExtractor, ArchiveExtractor
-from utils.template_utils import render_template
 
 
 # pylint: disable=too-many-instance-attributes
@@ -207,10 +206,10 @@ class SparkMapper(ActionMapper, PrepareMixin):
             else []
         )
 
-    def convert_to_text(self):
+    def to_tasks_and_relations(self):
         tasks = self._get_tasks()
         relations = self._get_relations()
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         # Bash are for the potential prepare statement

--- a/oozie-to-airflow/mappers/ssh_mapper.py
+++ b/oozie-to-airflow/mappers/ssh_mapper.py
@@ -23,8 +23,6 @@ from converter.primitives import Task, Relation
 from mappers.action_mapper import ActionMapper
 from utils import el_utils
 
-from utils.template_utils import render_template
-
 
 class SSHMapper(ActionMapper):
     """
@@ -72,7 +70,7 @@ class SSHMapper(ActionMapper):
         self.user = user_host[0]
         self.host = user_host[1]
 
-    def convert_to_text(self) -> str:
+    def to_tasks_and_relations(self):
         tasks = [
             Task(
                 task_id=self.name,
@@ -84,7 +82,7 @@ class SSHMapper(ActionMapper):
             )
         ]
         relations: List[Relation] = []
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         return {

--- a/oozie-to-airflow/mappers/start_mapper.py
+++ b/oozie-to-airflow/mappers/start_mapper.py
@@ -22,8 +22,8 @@ class StartMapper(BaseMapper):
     def required_imports(self) -> Set[str]:
         return set()
 
-    def convert_to_text(self) -> str:
-        return ""
+    def to_tasks_and_relations(self):
+        return [], []
 
     def on_parse_finish(self, workflow):
         super().on_parse_finish(self)

--- a/oozie-to-airflow/mappers/subworkflow_mapper.py
+++ b/oozie-to-airflow/mappers/subworkflow_mapper.py
@@ -26,7 +26,6 @@ from mappers.action_mapper import ActionMapper
 from mappers.base_mapper import BaseMapper
 from tests.utils.test_paths import EXAMPLES_PATH
 from utils import el_utils, xml_utils
-from utils.template_utils import render_template
 
 
 # pylint: disable=too-many-instance-attributes
@@ -104,7 +103,7 @@ class SubworkflowMapper(ActionMapper):
                     )
                     self.properties[name] = value
 
-    def convert_to_text(self):
+    def to_tasks_and_relations(self):
         tasks = [
             Task(
                 task_id=self.name,
@@ -114,7 +113,7 @@ class SubworkflowMapper(ActionMapper):
             )
         ]
         relations = []
-        return render_template(template_name="action.tpl", tasks=tasks, relations=relations)
+        return tasks, relations
 
     def required_imports(self) -> Set[str]:
         return {

--- a/oozie-to-airflow/tests/mappers/test_decision_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_decision_mapper.py
@@ -15,7 +15,6 @@
 """Tests decision_mapper"""
 import ast
 import unittest
-from unittest import mock
 from collections import OrderedDict
 
 from xml.etree import ElementTree as ET
@@ -48,21 +47,14 @@ class TestDecisionMapper(unittest.TestCase):
         # test conversion from Oozie EL to Jinja
         self.assertEqual("first_not_null('', '')", next(iter(mapper.case_dict)))
 
-    @mock.patch("mappers.decision_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_to_tasks_and_relations(self):
         # TODO
         # decision mapper does not have the required EL parsing to correctly get
         # parsed, so once that is finished need to redo tests.
         mapper = self._get_decision_mapper()
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [

--- a/oozie-to-airflow/tests/mappers/test_dummy_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_dummy_mapper.py
@@ -15,7 +15,6 @@
 """Tests for the Dummy mapper."""
 import ast
 import unittest
-from unittest import mock
 from xml.etree.ElementTree import Element
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -32,18 +31,11 @@ class TestDummyMapper(unittest.TestCase):
         self.assertEqual("test_id", mapper.name)
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
 
-    @mock.patch("mappers.dummy_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_convert_tasks_and_relations(self):
         mapper = self._get_dummy_mapper()
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(tasks, [Task(task_id="test_id", template_name="dummy.tpl")])
         self.assertEqual(relations, [])
 

--- a/oozie-to-airflow/tests/mappers/test_end_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_end_mapper.py
@@ -35,18 +35,11 @@ class TestEndMapper(unittest.TestCase):
         self.assertEqual("test_id", mapper.name)
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
 
-    @mock.patch("mappers.dummy_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_convert_tasks_and_relations(self):
         mapper = self._get_end_mapper()
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(tasks, [Task(task_id="test_id", template_name="dummy.tpl")])
         self.assertEqual(relations, [])
 

--- a/oozie-to-airflow/tests/mappers/test_fs_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_fs_mapper.py
@@ -16,7 +16,6 @@
 
 import ast
 import unittest
-from unittest import mock
 from xml.etree import ElementTree as ET
 
 from parameterized import parameterized
@@ -169,16 +168,9 @@ class FsMapperSingleTestCase(unittest.TestCase):
         self.mapper = _get_fs_mapper(oozie_node=self.node)
         self.mapper.on_parse_node()
 
-    @mock.patch("mappers.fs_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
-        res = self.mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+    def test_to_tasks_and_relations(self):
+        tasks, relations = self.mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [
@@ -209,15 +201,9 @@ class FsMapperEmptyTestCase(unittest.TestCase):
         self.mapper = _get_fs_mapper(oozie_node=self.node)
         self.mapper.on_parse_node()
 
-    @mock.patch("mappers.fs_mapper.render_template")
-    def test_convert_to_text(self, render_template_mock):
-        self.mapper.convert_to_text()
+    def test_to_tasks_and_relations(self):
+        tasks, relations = self.mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(tasks, [Task(task_id="test_id", template_name="dummy.tpl")])
         self.assertEqual(relations, [])
 
@@ -278,15 +264,9 @@ class FsMapperComplexTestCase(unittest.TestCase):
         self.mapper = _get_fs_mapper(oozie_node=self.node)
         self.mapper.on_parse_node()
 
-    @mock.patch("mappers.fs_mapper.render_template")
-    def test_convert_to_text(self, render_template_mock):
-        self.mapper.convert_to_text()
+    def test_to_tasks_and_relations(self):
+        tasks, relations = self.mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [

--- a/oozie-to-airflow/tests/mappers/test_kill_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_kill_mapper.py
@@ -35,20 +35,13 @@ class TestKillMapper(unittest.TestCase):
         self.assertEqual("test_id", mapper.name)
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
 
-    @mock.patch("mappers.kill_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_to_tasks_and_relations(self):
         mapper = kill_mapper.KillMapper(
             oozie_node=self.oozie_node, name="test_id", trigger_rule=TriggerRule.DUMMY
         )
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(tasks, [Task(task_id="test_id", template_name="kill.tpl")])
         self.assertEqual(relations, [])
 

--- a/oozie-to-airflow/tests/mappers/test_mapreduce_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_mapreduce_mapper.py
@@ -15,7 +15,6 @@
 """Tests for the MapReduce mapper"""
 import ast
 import unittest
-from unittest import mock
 from xml.etree import ElementTree as ET
 
 from airflow.utils.trigger_rule import TriggerRule
@@ -125,8 +124,7 @@ class TestMapReduceMapper(unittest.TestCase):
             mapper.properties["mapreduce.output.fileoutputformat.outputdir"],
         )
 
-    @mock.patch("mappers.mapreduce_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_to_tasks_and_relations(self):
         mapper = mapreduce_mapper.MapReduceMapper(
             oozie_node=self.mapreduce_node,
             name="test_id",
@@ -141,14 +139,8 @@ class TestMapReduceMapper(unittest.TestCase):
         )
         mapper.on_parse_node()
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [

--- a/oozie-to-airflow/tests/mappers/test_pig_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_pig_mapper.py
@@ -15,7 +15,6 @@
 """Tests pig mapper"""
 import ast
 import unittest
-from unittest import mock
 from xml.etree import ElementTree as ET
 
 from airflow.utils.trigger_rule import TriggerRule
@@ -102,19 +101,12 @@ class TestPigMapper(unittest.TestCase):
             "/user/${wf:user()}/examples/output-data/demo/pig-node", mapper.params_dict["OUTPUT"]
         )
 
-    @mock.patch("mappers.pig_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_to_tasks_and_relations(self):
         params = {"dataproc_cluster": "my-cluster", "gcp_region": "europe-west3", "nameNode": "hdfs://"}
         mapper = self._get_pig_mapper(params=params)
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [

--- a/oozie-to-airflow/tests/mappers/test_shell_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_shell_mapper.py
@@ -15,7 +15,6 @@
 """Tests shell mapper"""
 import ast
 import unittest
-from unittest import mock
 from xml.etree import ElementTree as ET
 
 from airflow.utils.trigger_rule import TriggerRule
@@ -86,22 +85,15 @@ class TestShellMapper(unittest.TestCase):
         self.assertEqual("myQueue", mapper.properties["mapred.job.queue.name"])
         self.assertEqual("echo arg1 arg2", mapper.bash_command)
 
-    @mock.patch("mappers.shell_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_to_tasks_and_relations(self):
         params = {
             "dataproc_cluster": "my-cluster",
             "gcp_region": "europe-west3",
             "nameNode": "hdfs://localhost:9020/",
         }
         mapper = self._get_shell_mapper(params=params)
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [

--- a/oozie-to-airflow/tests/mappers/test_ssh_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_ssh_mapper.py
@@ -15,7 +15,6 @@
 """Tests for SSH mapper"""
 import ast
 import unittest
-from unittest import mock
 
 from xml.etree import ElementTree as ET
 from airflow.utils.trigger_rule import TriggerRule
@@ -62,18 +61,11 @@ class TestSSHMapper(unittest.TestCase):
         self.assertEqual("apache.org", mapper.host)
         self.assertEqual("'ls -l -a'", mapper.command)
 
-    @mock.patch("mappers.ssh_mapper.render_template", return_value="RETURN")
-    def test_convert_to_text(self, render_template_mock):
+    def test_to_tasks_and_relations(self):
         mapper = self._get_ssh_mapper()
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
         self.assertEqual(
             tasks,
             [

--- a/oozie-to-airflow/tests/mappers/test_start_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_start_mapper.py
@@ -34,9 +34,11 @@ class TestStartMapper(unittest.TestCase):
         self.assertEqual("test_id", mapper.name)
         self.assertEqual(TriggerRule.DUMMY, mapper.trigger_rule)
 
-    def test_convert_to_text(self):
+    def test_to_tasks_and_relations(self):
         mapper = self._get_start_mapper()
-        self.assertEqual("", mapper.convert_to_text())
+        tasks, relations = mapper.to_tasks_and_relations()
+        self.assertEqual(tasks, [])
+        self.assertEqual(relations, [])
 
     def test_required_imports(self):
         mapper = self._get_start_mapper()

--- a/oozie-to-airflow/tests/mappers/test_subworkflow_mapper.py
+++ b/oozie-to-airflow/tests/mappers/test_subworkflow_mapper.py
@@ -105,22 +105,15 @@ class TestSubworkflowMapper(TestCase):
         self.assertEqual({}, mapper.get_config_properties())
         self.assertTrue(os.path.isfile(self.SUBDAG_TEST_FILEPATH))
 
-    @mock.patch("mappers.subworkflow_mapper.render_template", return_value="RETURN")
     @mock.patch("utils.el_utils.parse_els")
-    def test_convert_to_text(self, parse_els_mock, render_template_mock):
+    def test_to_tasks_and_relations(self, parse_els_mock):
         # Given
         parse_els_mock.return_value = self.subworkflow_params
-        # When
         mapper = self._get_subwf_mapper()
+        # When
+        tasks, relations = mapper.to_tasks_and_relations()
 
-        res = mapper.convert_to_text()
-        self.assertEqual(res, "RETURN")
-
-        _, kwargs = render_template_mock.call_args
-        tasks = kwargs["tasks"]
-        relations = kwargs["relations"]
-
-        self.assertEqual(kwargs["template_name"], "action.tpl")
+        # Then
         self.assertEqual(
             tasks, [Task(task_id="test_id", template_name="subwf.tpl", template_params={"app_name": "pig"})]
         )


### PR DESCRIPTION
Hello,

This is part of:
https://github.com/GoogleCloudPlatform/cloud-composer/pull/146

This is good because:

- This allows for easier mapper testing. 
- This introduces the structure in the code. The processing mechanisms are more closely separated from the rendering process.
- In the long run it allows much more complex workflow operations ex. add/remove tasks/relations.  It's requred by https://github.com/GoogleCloudPlatform/cloud-composer/issues/132
- This will allow the development of development tools https://github.com/GoogleCloudPlatform/cloud-composer/issues/162

Thanks