### PR TITLE
Add setup wizard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ install:
   - pip install -r ../requirements.txt
   - sudo apt-get install coreutils libxml2-utils
 script:
+  - echo "COMPOSER_DAG_BUCKET" > .COMPOSER_DAG_BUCKET
+  - echo "COMPOSER_LOCATION" > .COMPOSER_LOCATION
+  - echo "COMPOSER_NAME" > .COMPOSER_NAME
+  - echo "DATAPROC_CLUSTER_NAME" > .DATAPROC_CLUSTER_NAME
+  - echo "GCP_REGION" > .GCP_REGION
   - ./run-all-conversions
   - pre-commit run --all-files
 after_success:

--- a/oozie-to-airflow/confirm
+++ b/oozie-to-airflow/confirm
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-read -r -p "${1}. Are you sure? [y/N] " response
+read -r -p "${1} [y/N] " response
 case "$response" in
     [yY][eE][sS]|[yY])
         exit 0

--- a/oozie-to-airflow/run-sys-test
+++ b/oozie-to-airflow/run-sys-test
@@ -70,21 +70,21 @@ COMPOSER_WEB_UI_URL=""
 VERBOSE="false"
 
 function setup_configuration {
-    read -p "Enter Composer name [${COMPOSER_NAME}]: " input
+    read -r -p "Enter Composer name [${COMPOSER_NAME}]: " input
     COMPOSER_NAME=${input:-COMPOSER_NAME}
 
-    read -p "Enter Composer location [${COMPOSER_LOCATION}]: " input
+    read -r -p "Enter Composer location [${COMPOSER_LOCATION}]: " input
     COMPOSER_LOCATION=${input:-COMPOSER_LOCATION}
 
-    read -p "Enter Dataproc cluster name [${DATAPROC_CLUSTER_NAME}]: " input
+    read -r -p "Enter Dataproc cluster name [${DATAPROC_CLUSTER_NAME}]: " input
     DATAPROC_CLUSTER_NAME=${input:-DATAPROC_CLUSTER_NAME}
 
-    read -p "Enter GCP Region [${GCP_REGION}]: " input
+    read -r -p "Enter GCP Region [${GCP_REGION}]: " input
     GCP_REGION=${input:-GCP_REGION}
 
     "${MY_DIR}/confirm" "Do you want to configure additional options?"
 
-    read -p "Enter the name of the bucket that is used to store DAGs [${COMPOSER_DAG_BUCKET}]: " input
+    read -r -p "Enter the name of the bucket that is used to store DAGs [${COMPOSER_DAG_BUCKET}]: " input
     COMPOSER_DAG_BUCKET=${input:-COMPOSER_DAG_BUCKET}
 }
 

--- a/oozie-to-airflow/run-sys-test
+++ b/oozie-to-airflow/run-sys-test
@@ -36,19 +36,19 @@ function read_from_file {
 
 
 DATAPROC_CLUSTER_NAME=$(read_from_file DATAPROC_CLUSTER_NAME)
-export DATAPROC_CLUSTER_NAME=${DATAPROC_CLUSTER_NAME:=oozie-51}
+export DATAPROC_CLUSTER_NAME=${DATAPROC_CLUSTER_NAME:=}
 
 GCP_REGION=$(read_from_file GCP_REGION)
-export GCP_REGION=${GCP_REGION:=europe-west3}
+export GCP_REGION=${GCP_REGION:=}
 
 COMPOSER_NAME=$(read_from_file COMPOSER_NAME)
-export COMPOSER_NAME=${COMPOSER_NAME:=o2a-integration}
+export COMPOSER_NAME=${COMPOSER_NAME:=}
 
 COMPOSER_LOCATION=$(read_from_file COMPOSER_LOCATION)
-export COMPOSER_LOCATION=${COMPOSER_LOCATION:=europe-west1}
+export COMPOSER_LOCATION=${COMPOSER_LOCATION:=}
 
 COMPOSER_DAG_BUCKET=$(read_from_file COMPOSER_DAG_BUCKET)
-export COMPOSER_DAG_BUCKET=${COMPOSER_DAG_BUCKET:=europe-west1-o2a-integratio-f690ede2-bucket}
+export COMPOSER_DAG_BUCKET=${COMPOSER_DAG_BUCKET:=}
 
 LOCAL_APP_NAME=$(read_from_file LOCAL_APP_NAME)
 export LOCAL_APP_NAME=${LOCAL_APP_NAME:=}
@@ -246,7 +246,7 @@ function setup_autocomplete {
     if [[ "${RES}" == "0" ]]; then
         echo "Bash dir already created"
     else
-        "${MY_DIR}/confirm" "This will create ~/.bash_completion.d/ directory and modify ~/.bash_profile file"
+        "${MY_DIR}/confirm" "This will create ~/.bash_completion.d/ directory and modify ~/.bash_profile file. Are you sure?"
         echo
         echo
         mkdir -pv ~/.bash_completion.d
@@ -414,6 +414,17 @@ function ssh_to_cluster_master {
     gcloud compute ssh "${DATAPROC_CLUSTER_MASTER}" --zone "${DATAPROC_MASTER_ZONE}" -- $@
 }
 
+function verify_configuration {
+    if [[ -z "${COMPOSER_NAME}" ]] || [[ -z "${COMPOSER_LOCATION}" ]] \
+    || [[ -z "${DATAPROC_CLUSTER_NAME}" ]] || [[ -z "${GCP_REGION}" ]]; then
+        echo "It looks like you are launching this setup for the first time."
+        echo ""
+        echo "Starting the configuration wizard."
+        echo ""
+        setup_configuration
+    fi
+}
+
 function verify_arguments {
     if [[ ${LOCAL_APP_NAME} == "" ]]; then
         echo
@@ -545,6 +556,8 @@ function fetch_dataproc_environment_info {
 if [[ ${VERBOSE} == "true" ]]; then
     set -x
 fi
+
+verify_configuration
 
 if [[ ${RUN_SSH_COMMAND} == "true" ]]; then
     fetch_dataproc_environment_info

--- a/oozie-to-airflow/run-sys-test
+++ b/oozie-to-airflow/run-sys-test
@@ -61,11 +61,32 @@ export DATAPROC_USER=${DATAPROC_USER:=${USER:=example_user}}
 
 RUN_SSH_COMMAND="false"
 
+SETUP_CONFIGURATION="false"
+
 SETUP_AUTOCOMPLETE="false"
 
 COMPOSER_WEB_UI_URL=""
 
 VERBOSE="false"
+
+function setup_configuration {
+    read -p "Enter Composer name [${COMPOSER_NAME}]: " input
+    COMPOSER_NAME=${input:-COMPOSER_NAME}
+
+    read -p "Enter Composer location [${COMPOSER_LOCATION}]: " input
+    COMPOSER_LOCATION=${input:-COMPOSER_LOCATION}
+
+    read -p "Enter Dataproc cluster name [${DATAPROC_CLUSTER_NAME}]: " input
+    DATAPROC_CLUSTER_NAME=${input:-DATAPROC_CLUSTER_NAME}
+
+    read -p "Enter GCP Region [${GCP_REGION}]: " input
+    GCP_REGION=${input:-GCP_REGION}
+
+    "${MY_DIR}/confirm" "Do you want to configure additional options?"
+
+    read -p "Enter the name of the bucket that is used to store DAGs [${COMPOSER_DAG_BUCKET}]: " input
+    COMPOSER_DAG_BUCKET=${input:-COMPOSER_DAG_BUCKET}
+}
 
 function prepare_configuration {
     if [[ ! -f "${LOCAL_CONFIGURATION_PROPERTIES_TEMPLATE}" ]]; then
@@ -186,6 +207,9 @@ Optional commands to execute:
 
 -A, --setup-autocomplete
         Sets up autocomplete for run-sys-tests
+
+-X, --setup-configuration
+        Sets up configuration for run-sys-tests
 
 """
 }
@@ -356,6 +380,12 @@ do
       echo "Running SSH to master"
       echo
       shift ;;
+    -X|--setup-configuration)
+      export SETUP_CONFIGURATION="true"
+      echo
+      echo "Setting up configuration"
+      echo
+      shift ;;
     -A|--setup-autocomplete)
       export SETUP_AUTOCOMPLETE="true"
       echo
@@ -520,6 +550,11 @@ if [[ ${RUN_SSH_COMMAND} == "true" ]]; then
     fetch_dataproc_environment_info
     # shellcheck disable=SC2068
     ssh_to_cluster_master $@
+    exit
+fi
+
+if [[ ${SETUP_CONFIGURATION} == "true" ]]; then
+    setup_configuration
     exit
 fi
 

--- a/oozie-to-airflow/run-sys-test
+++ b/oozie-to-airflow/run-sys-test
@@ -71,21 +71,26 @@ VERBOSE="false"
 
 function setup_configuration {
     read -r -p "Enter Composer name [${COMPOSER_NAME}]: " input
-    COMPOSER_NAME=${input:-COMPOSER_NAME}
+    [[ -n "${input}" ]] && COMPOSER_NAME="${input}"
+    save_to_file COMPOSER_NAME
 
     read -r -p "Enter Composer location [${COMPOSER_LOCATION}]: " input
-    COMPOSER_LOCATION=${input:-COMPOSER_LOCATION}
+    [[ -n "${input}" ]] && COMPOSER_LOCATION="${input}"
+    save_to_file COMPOSER_LOCATION
 
     read -r -p "Enter Dataproc cluster name [${DATAPROC_CLUSTER_NAME}]: " input
-    DATAPROC_CLUSTER_NAME=${input:-DATAPROC_CLUSTER_NAME}
+    [[ -n "${input}" ]] && DATAPROC_CLUSTER_NAME="${input}"
+    save_to_file DATAPROC_CLUSTER_NAME
 
     read -r -p "Enter GCP Region [${GCP_REGION}]: " input
-    GCP_REGION=${input:-GCP_REGION}
+    [[ -n "${input}" ]] && GCP_REGION="${input}"
+    save_to_file GCP_REGION
 
     "${MY_DIR}/confirm" "Do you want to configure additional options?"
 
     read -r -p "Enter the name of the bucket that is used to store DAGs [${COMPOSER_DAG_BUCKET}]: " input
     COMPOSER_DAG_BUCKET=${input:-COMPOSER_DAG_BUCKET}
+    save_to_file COMPOSER_DAG_BUCKET
 }
 
 function prepare_configuration {

--- a/oozie-to-airflow/run-sys-test-complete
+++ b/oozie-to-airflow/run-sys-test-complete
@@ -16,7 +16,7 @@
 _MY_LINKED_DIR="$( cd "$( dirname "$(readlink "${BASH_SOURCE[0]}" )" )" && pwd )"
 
 _SHORT_OPTIONS="
-h a: p: C: L: b: c: m: r: z: v A S
+h a: p: C: L: b: c: m: r: z: v X A S
 "
 
 _ALLOWED_PHASES=" prepare-configuration convert prepare-dataproc test-composer test-oozie "
@@ -25,7 +25,7 @@ _ALLOWED_APPLICATIONS=" $(ls "${_MY_LINKED_DIR}/examples" | xargs) "
 
 _LONG_OPTIONS="
 help application: composer-name: composer-location: phase: bucket: cluster:
-region: verbose setup-autocomplete ssh-to-cluster-master
+region: verbose setup-configuration setup-autocomplete ssh-to-cluster-master
 "
 
 # Note on OSX bash has no associative arrays (Bash 3.2) so we have to fake it


### PR DESCRIPTION
Hello,

The configuration of our tools is becoming more and more complex. So I added the configuration wizard. 

This is needed because git mapper needs to specify additional configuration options, but I think creating an additional CLI flag from one case is too hasty. The configuration wizard allows easy configuration of the environment even when some options are very rarely used.

Thanks,